### PR TITLE
feat(GrandArchiveSim): add match telemetry and bot playtesting

### DIFF
--- a/APIKeys/APIKeys.php.template
+++ b/APIKeys/APIKeys.php.template
@@ -25,6 +25,13 @@ $patreonClientSecret = "op://$APP_ENV/Patreon/credential";
 $petranakiAPIKey = "";
 $karabastAPIKey = "";
 
+// Grand Archive match telemetry — POSTed once per decided game to your own hosted stats API.
+// See GrandArchiveSim/StatsSubmit.php. Leave the URL blank to disable submission (statsStatus
+// will record as 'skipped_unconfigured').
+$grandArchiveStatsApiUrl = ""; // e.g. https://your-host.example.com/api/grand-archive/submit-game
+$grandArchiveStatsApiKey = "";
+$grandArchiveStatsSourceVersion = "unknown"; // deployed commit SHA or release identifier
+
 $bugReportApiKey = "";
 $bugReportApiUrl = "https://soulmastersdb.net/TCGEngine-Discord/APIs/BugReportAPI.php";
 

--- a/APIs/Lobbies/JoinQueue.php
+++ b/APIs/Lobbies/JoinQueue.php
@@ -69,6 +69,18 @@
   $azukiRlBotProfile = function_exists('NormalizeAzukiRlBotProfile')
     ? NormalizeAzukiRlBotProfile($_POST['rlBotOpponent'] ?? 'raizan')
     : 'raizan';
+  // GA heuristic-bot self-play (see GrandArchiveSim/BotController.php). botPlayers defaults to
+  // both seats (full self-play, e.g. for automated regression matches); pass a single seat for a
+  // human-vs-bot game instead.
+  $createBot = isset($_POST['createBot']) && ($_POST['createBot'] === '1' || strtolower($_POST['createBot']) === 'true');
+  $gaBotPlayers = [];
+  if (isset($_POST['botPlayers'])) {
+    foreach (explode(',', strval($_POST['botPlayers'])) as $seatStr) {
+      $seat = intval(trim($seatStr));
+      if ($seat === 1 || $seat === 2) $gaBotPlayers[] = $seat;
+    }
+  }
+  if (empty($gaBotPlayers)) $gaBotPlayers = [1, 2];
   $createTutorial = isset($_POST['createTutorial']) && ($_POST['createTutorial'] === '1' || strtolower($_POST['createTutorial']) === 'true');
   $casterMode = isset($_POST['casterMode']) && ($_POST['casterMode'] === '1' || strtolower($_POST['casterMode']) === 'true');
   $privateInviteCode = isset($_POST['privateInviteCode']) ? trim($_POST['privateInviteCode']) : '';
@@ -112,7 +124,7 @@
   // 'hotseat' = 2 decks, shared authKey.
   $isModeFormat =
       ($rootName === 'SWUSim'         && ($format === 'goldfish' || $format === 'hotseat')) ||
-      ($rootName === 'GrandArchiveSim' && ($format === 'goldfish' || $format === 'hotseat')) ||
+      ($rootName === 'GrandArchiveSim' && ($format === 'goldfish' || $format === 'hotseat' || $format === 'bot')) ||
       ($rootName === 'AzukiSim'        && ($format === 'rlbot' || $format === 'tutorial')) ||
       ($rootName === 'HellbreakSim'    && $format === 'tutorial');
   // Guard: for SWUSim, fall back to safe defaults on unknown/garbage. (Other roots ignore these.)
@@ -173,17 +185,19 @@
   $response->success = false;
   $response->message = "Failed to join queue.";
 
-  if ($createGoldfish || $createRlBot || $createTutorial || $isModeFormat) {
+  if ($createGoldfish || $createRlBot || $createBot || $createTutorial || $isModeFormat) {
     // Normalize: the legacy createGoldfish param maps to the goldfish mode format.
     if ($createGoldfish && !$isModeFormat) $format = 'goldfish';
     if ($createRlBot && $rootName === 'AzukiSim') $format = 'rlbot';
+    if ($createBot && $rootName === 'GrandArchiveSim' && !$isModeFormat) $format = 'bot';
     if ($createTutorial && in_array($rootName, ['AzukiSim', 'HellbreakSim'], true)) $format = 'tutorial';
     $isHotseat = ($format === 'hotseat');
+    $isGABot = ($rootName === 'GrandArchiveSim' && $format === 'bot');
     $isAzukiRlBot = ($rootName === 'AzukiSim' && $format === 'rlbot');
     $isAzukiTutorial = ($rootName === 'AzukiSim' && $format === 'tutorial');
     $isHellbreakTutorial = ($rootName === 'HellbreakSim' && $format === 'tutorial');
     $isTutorial = $isAzukiTutorial || $isHellbreakTutorial;
-    // Goldfish/Hotseat are Bo1-only for now (leave Bo3 open for later): force Bo1 regardless of input.
+    // Goldfish/Hotseat/Bot are Bo1-only for now (leave Bo3 open for later): force Bo1 regardless of input.
     $queueType = 'bo1';
 
     // Tutorials always use the authored starter scenario, independent of the queue form's deck choice.
@@ -204,6 +218,11 @@
     } else if ($isHotseat) {
       // Hotseat: a real second deck; one person plays both seats.
       $secondPlayer = new Player(2, $deckLink2, '', $joiningUserId);
+    } else if ($isGABot) {
+      // Bot self-play: a real second deck too (a bot-controlled seat still needs an actual deck to
+      // pilot, unlike goldfish's empty dummy) — default to the same deck as P1 if none was supplied,
+      // so a single decklist can be tested against itself with one request.
+      $secondPlayer = new Player(2, $deckLink2 !== '' ? $deckLink2 : $deckLink, '', $joiningUserId);
     } else {
       // Goldfish: P2 is an empty passive seat (SWUSetupGame no longer gates pregame on it).
       $secondPlayer = new Player(2, '', '');
@@ -213,14 +232,15 @@
     $lobby->numPlayers = 2;
     $lobby->maxPlayers = 2;
     $lobby->ready = true;
-    $lobby->id = uniqid($isTutorial ? 'tutorial_' : ($isAzukiRlBot ? 'rlbot_' : ($isHotseat ? 'hotseat_' : 'goldfish_')), true);
+    $lobby->id = uniqid($isTutorial ? 'tutorial_' : ($isAzukiRlBot ? 'rlbot_' : ($isHotseat ? 'hotseat_' : ($isGABot ? 'bot_' : 'goldfish_'))), true);
     $lobby->rootName = $rootName;
     $lobby->format = $format;
     $lobby->queueType = $queueType;
     $lobby->isPrivate = true;
     $lobby->casterMode = $casterMode;
     $lobby->isGoldfish = true;            // reuse the "skip matchmaking / skip Bo3 match" plumbing
-    $lobby->goldfishPlayers = $isHotseat ? [] : [2];
+    $lobby->goldfishPlayers = ($isHotseat || $isGABot) ? [] : [2];
+    $lobby->botPlayers = $isGABot ? $gaBotPlayers : [];
     $lobby->azukiRlBotPlayers = $isAzukiRlBot ? [2] : [];
     $lobby->azukiRlBotProfile = $isAzukiRlBot ? $azukiRlBotProfile : '';
     $lobby->players = [$hostPlayer, $secondPlayer];

--- a/APIs/Lobbies/JoinQueue.php
+++ b/APIs/Lobbies/JoinQueue.php
@@ -84,6 +84,10 @@
   $createTutorial = isset($_POST['createTutorial']) && ($_POST['createTutorial'] === '1' || strtolower($_POST['createTutorial']) === 'true');
   $casterMode = isset($_POST['casterMode']) && ($_POST['casterMode'] === '1' || strtolower($_POST['casterMode']) === 'true');
   $privateInviteCode = isset($_POST['privateInviteCode']) ? trim($_POST['privateInviteCode']) : '';
+  // Grand Archive analytics sharing is opt-out. Legacy clients that omit the field retain the
+  // default-on behavior; a match shares only when every participant leaves it enabled.
+  $shareAnonymizedGameplayData = !isset($_POST['shareAnonymizedGameplayData'])
+    || in_array(strtolower(trim(strval($_POST['shareAnonymizedGameplayData']))), ['1', 'true', 'yes', 'on'], true);
 
   $format = isset($_POST['format']) ? strtolower(trim($_POST['format'])) : 'premier';
   if ($createRlBot && $rootName === 'AzukiSim') {
@@ -237,6 +241,7 @@
     $lobby->format = $format;
     $lobby->queueType = $queueType;
     $lobby->isPrivate = true;
+    if ($rootName === 'GrandArchiveSim') $lobby->shareAnonymizedGameplayData = $shareAnonymizedGameplayData;
     $lobby->casterMode = $casterMode;
     $lobby->isGoldfish = true;            // reuse the "skip matchmaking / skip Bo3 match" plumbing
     $lobby->goldfishPlayers = ($isHotseat || $isGABot) ? [] : [2];
@@ -297,6 +302,9 @@
         if (($lobby->rootName === 'SWUSim') && (($lobby->format ?? '') === 'twinsuns') && !empty($lobby->gameName)) continue; // already started
 
         $lobby->numPlayers++;
+        if ($rootName === 'GrandArchiveSim') {
+          $lobby->shareAnonymizedGameplayData = !empty($lobby->shareAnonymizedGameplayData) && $shareAnonymizedGameplayData;
+        }
         $isTwinSunsRoom = ($lobby->rootName === 'SWUSim' && ($lobby->format ?? '') === 'twinsuns');
         if (!$isTwinSunsRoom && $lobby->numPlayers == $lobby->maxPlayers) {
           $lobby->ready = true;   // 2-seat: fill = ready (unchanged)
@@ -363,6 +371,7 @@
     $lobby->format = $format;
     $lobby->queueType = $queueType;
     $lobby->isPrivate = true;
+    if ($rootName === 'GrandArchiveSim') $lobby->shareAnonymizedGameplayData = $shareAnonymizedGameplayData;
     $lobby->casterMode = $casterMode;
     $lobby->hostUserId = $joiningUserId;
     $lobby->inviteCode = bin2hex(random_bytes(12));
@@ -416,6 +425,9 @@
           ) {
               if (SWUJoinBlocked($joiningUserId, SWULobbyHostUserId($lobby))) continue; // skip blocked host, keep scanning
               $lobby->numPlayers++;
+              if ($rootName === 'GrandArchiveSim') {
+                $lobby->shareAnonymizedGameplayData = !empty($lobby->shareAnonymizedGameplayData) && $shareAnonymizedGameplayData;
+              }
               if($lobby->numPlayers == $lobby->maxPlayers) {
                   $lobby->ready = true;
               }
@@ -470,6 +482,7 @@
       $lobby->format = $format;
       $lobby->queueType = $queueType;
       $lobby->isPrivate = false;
+      if ($rootName === 'GrandArchiveSim') $lobby->shareAnonymizedGameplayData = $shareAnonymizedGameplayData;
       $lobby->casterMode = $casterMode;
       $newPlayer = new Player(1, $deckLink, $preconstructedDeck, $joiningUserId);
       $lobby->players = array($newPlayer);

--- a/Core/Match/MatchFlow.php
+++ b/Core/Match/MatchFlow.php
@@ -135,6 +135,12 @@ function MatchCreateFromLobby($rootName, $lobby) {
     }
 
     $matchId = MatchCreate($rootName, $format, $queueType, $resolved, !empty($lobby->isPrivate));
+    if (isset($lobby->shareAnonymizedGameplayData)) {
+        $shareAnonymizedGameplayData = !empty($lobby->shareAnonymizedGameplayData);
+        MatchWithLock($rootName, $matchId, function (&$m) use ($shareAnonymizedGameplayData) {
+            $m['shareAnonymizedGameplayData'] = $shareAnonymizedGameplayData;
+        });
+    }
 
     // Spawn game 1 from the real lobby, injecting the already-resolved decks. matchId/gameNumber are
     // offered so a sim's setupGame MAY stamp them into the gamestate for its own client match-detection
@@ -272,6 +278,12 @@ function MatchAcceptRematch($rootName, $oldMatchId) {
         1 => ['originalDeck' => $m['players']['1']['originalDeck'] ?? [], 'authKey' => $m['players']['1']['authKey'] ?? ''],
         2 => ['originalDeck' => $m['players']['2']['originalDeck'] ?? [], 'authKey' => $m['players']['2']['authKey'] ?? ''],
     ], !empty($m['isPrivate']));   // a private match rematches private (no forced sideboard timer)
+    if (array_key_exists('shareAnonymizedGameplayData', $m)) {
+        $shareAnonymizedGameplayData = !empty($m['shareAnonymizedGameplayData']);
+        MatchWithLock($rootName, $newId, function (&$newMatch) use ($shareAnonymizedGameplayData) {
+            $newMatch['shareAnonymizedGameplayData'] = $shareAnonymizedGameplayData;
+        });
+    }
     MatchWithLock($rootName, $oldMatchId, function (&$mm) { unset($mm['rematchRequests']); }); // fire once
 
     $oldGame = !empty($m['games']) ? $m['games'][count($m['games'])-1]['gameName'] : '';

--- a/DevTools/GABotSelfPlayTest.php
+++ b/DevTools/GABotSelfPlayTest.php
@@ -1,0 +1,292 @@
+<?php
+// Headless bot-vs-bot self-play test for GrandArchiveSim — no browser, no HTTP, no APCu-auth
+// plumbing. Drives the bot the same way the real client's polling loop does (mode 10017 →
+// GrandArchiveSim/BotController.php's ProcessBotControllerStep(), which enumerates legal actions
+// via BotLegalActions.php and executes the chosen one via Core/EngineActionRunner.php's
+// EngineExecuteLoadedAction()) but calls that function directly in a single CLI process, the same
+// way DevTools/RunIntegrationTests.php drives scripted regression fixtures.
+//
+// Verifies two things end to end, from a real 60-card decklist on each side:
+//   1. The bot can pilot a full self-play game to completion without stalling (no unrecognized
+//      decision type, no infinite no-op loop).
+//   2. The telemetry pipeline (GrandArchiveSim/Telemetry.php + StatsSubmit.php) populates
+//      correctly from bot-driven actions — the same assertion that used to require manually
+//      curling GrandArchiveSim/DevToolsDebugTelemetry.php against a hand-played game.
+//
+// Usage (run inside the GA web-server container, where the live card dictionary + DB are set up):
+//   docker exec -w /var/www/html/TCGEngine <container> \
+//     php -d apc.enable_cli=1 -d xdebug.mode=off DevTools/GABotSelfPlayTest.php \
+//     [--deck=<path>] [--deck2=<path>] [--max-steps=2000] [--verbose]
+//
+// `apc.enable_cli=1` is required — GASetupGame() stores auth metadata via APCu
+// (SimGameWriteAuthKeysFromLobby) and throws if that store fails; CLI SAPI disables APCu by
+// default. Since this whole test runs as one continuous process (no separate requests), that
+// APCu state never needs to survive past this one invocation.
+//
+// Defaults to the two fixture decklists in GrandArchiveSim/Tests/BotFixtures/ (real 2026 World
+// Championship lists, pulled from FanOfIn.Site's event data) so the test is runnable with no args.
+
+// Homebrew PHP does not ship APCu by default. This harness is deliberately one CLI process, so an
+// in-memory compatibility layer has the same lifetime and semantics it needs from APCu without a
+// system-wide extension install. Production/web requests continue to use the real extension.
+if (!function_exists('apcu_store')) {
+  $GLOBALS['GABotTestUsingApcuFallback'] = true;
+  $GLOBALS['GABotTestApcu'] = [];
+  function apcu_store($key, $value, $ttl = 0) {
+    $GLOBALS['GABotTestApcu'][strval($key)] = $value;
+    return true;
+  }
+  function apcu_fetch($key, &$success = null) {
+    $key = strval($key);
+    $success = array_key_exists($key, $GLOBALS['GABotTestApcu']);
+    return $success ? $GLOBALS['GABotTestApcu'][$key] : false;
+  }
+  function apcu_exists($key) {
+    return array_key_exists(strval($key), $GLOBALS['GABotTestApcu']);
+  }
+  function apcu_delete($key) {
+    $key = strval($key);
+    $existed = array_key_exists($key, $GLOBALS['GABotTestApcu']);
+    unset($GLOBALS['GABotTestApcu'][$key]);
+    return $existed;
+  }
+  function apcu_inc($key, $step = 1, &$success = null, $ttl = 0) {
+    $key = strval($key);
+    if (!array_key_exists($key, $GLOBALS['GABotTestApcu'])) {
+      $success = false;
+      return false;
+    }
+    $GLOBALS['GABotTestApcu'][$key] += $step;
+    $success = true;
+    return $GLOBALS['GABotTestApcu'][$key];
+  }
+}
+
+require_once __DIR__ . '/../Core/EngineActionRunner.php';
+require_once __DIR__ . '/../APIs/Lobbies/Classes/Player.php';
+// Loads the same runtime a real request has for GA actions (Core/NetworkingLibraries.php in
+// particular — WriteCache() etc. — which EngineExecuteLoadedAction's cache bookkeeping needs but
+// CreateGame.php's own include list doesn't pull in on its own).
+EngineLoadRootRuntime('GrandArchiveSim');
+if (!empty($GLOBALS['GABotTestUsingApcuFallback'])) $GLOBALS['APCuEnabled'] = true;
+// No ambient $lobby here, so CreateGame.php's auto-run guard stays quiet; this just defines
+// GASetupGame() (and pulls in GameLogic.php, which in turn pulls in Telemetry/BotController/etc).
+require_once __DIR__ . '/../GrandArchiveSim/CreateGame.php';
+
+function BotTestParseArgs($argv) {
+  $args = ['deck' => null, 'deck2' => null, 'maxSteps' => 2000, 'verbose' => false, 'deterministic' => true, 'payloadOut' => null];
+  foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--deck=')) $args['deck'] = substr($arg, 7);
+    elseif (str_starts_with($arg, '--deck2=')) $args['deck2'] = substr($arg, 8);
+    elseif (str_starts_with($arg, '--max-steps=')) $args['maxSteps'] = intval(substr($arg, 12));
+    elseif ($arg === '--verbose') $args['verbose'] = true;
+    elseif ($arg === '--random-shuffle') $args['deterministic'] = false;
+    elseif (str_starts_with($arg, '--payload-out=')) $args['payloadOut'] = substr($arg, 14);
+  }
+  return $args;
+}
+
+$args = BotTestParseArgs($argv);
+$fixtureDir = __DIR__ . '/../GrandArchiveSim/Tests/BotFixtures';
+$deckPath1 = $args['deck'] ?? ($fixtureDir . '/worlds2026_deck_a.txt');
+$deckPath2 = $args['deck2'] ?? ($fixtureDir . '/worlds2026_deck_b.txt');
+
+if (!is_file($deckPath1)) { fwrite(STDERR, "deck file not found: $deckPath1\n"); exit(1); }
+if (!is_file($deckPath2)) { fwrite(STDERR, "deck file not found: $deckPath2\n"); exit(1); }
+
+$checks = [];   // [label, passed, detail]
+function BotTestCheck(&$checks, $label, $passed, $detail = '') {
+  $checks[] = [$label, $passed, $detail];
+}
+
+function BotTestStallDiagnostic($gaDir, $gameName, $reason = 'state') {
+  ParseGamestate($gaDir);
+  $decisionQueues = [];
+  foreach ([1, 2] as $seat) {
+    foreach (GetDecisionQueue($seat) as $entry) {
+      if ($entry === null || !empty($entry->removed)) continue;
+      $decisionQueues[] = [
+        'seat' => $seat,
+        'type' => strval($entry->Type ?? ''),
+        'param' => strval($entry->Param ?? ''),
+        'priority' => intval($entry->Priority ?? 0),
+      ];
+    }
+  }
+  $effectStack = [];
+  foreach (GetEffectStack() as $obj) {
+    if ($obj === null || !empty($obj->removed)) continue;
+    $effectStack[] = [
+      'cardId' => strval($obj->CardID ?? ''),
+      'controller' => intval($obj->Controller ?? 0),
+      'turnEffects' => array_values($obj->TurnEffects ?? []),
+    ];
+  }
+  $turnPlayer = GetTurnPlayer();
+  $phase = GetCurrentPhase();
+  $pending = function_exists('GABotPendingDecisionPlayer') ? GABotPendingDecisionPlayer() : 0;
+  echo '[' . strtoupper($reason) . '] ' . json_encode([
+    'gameName' => $gameName,
+    'turnPlayer' => intval($turnPlayer),
+    'phase' => strval($phase),
+    'pendingDecisionPlayer' => $pending,
+    'decisionQueues' => $decisionQueues,
+    'effectStack' => $effectStack,
+  ], JSON_UNESCAPED_SLASHES) . "\n";
+}
+
+// ── Build a bot-vs-bot game directly in-process (mirrors JoinQueue.php's createBot branch, minus
+// the HTTP/matchmaking layer — a CLI test drives GASetupGame() itself). ──────────────────────────
+$lobby = new stdClass();
+$lobby->numPlayers = 2;
+$lobby->maxPlayers = 2;
+$lobby->format = 'bot';
+$lobby->isGoldfish = true;
+$lobby->goldfishPlayers = [];
+$lobby->botPlayers = [1, 2];
+$lobby->players = [
+  new Player(1, file_get_contents($deckPath1), ''),
+  new Player(2, file_get_contents($deckPath2), ''),
+];
+
+$gameName = GASetupGame($lobby, ['deterministicShuffle' => $args['deterministic']]);
+$lastChampions = ['1' => GASnapshotChampion(1), '2' => GASnapshotChampion(2)];
+if ($args['verbose']) echo "[INFO] game created: {$gameName}\n";
+
+// ── Drive the bot to completion ─────────────────────────────────────────────────────────────────
+$maxConsecutiveNoOps = 20; // same philosophy as BotController.php's own no-op guard: a handful of
+                           // doomed-but-offered actions in a row is normal; that many with zero
+                           // progress means the bot is genuinely stuck.
+$steps = 0;
+$consecutiveNoOps = 0;
+$stalled = false;
+$gameOver = false;
+$winner = 0;
+
+$gaDir = __DIR__ . '/../GrandArchiveSim/';
+
+for (; $steps < $args['maxSteps']; $steps++) {
+  // Re-parse before every step, mirroring what a real HTTP request does on every poll (mode 10017):
+  // ParseGamestate() reconstructs each zone object fresh from the wire text, correctly stamping
+  // Location/PlayerID/mzIndex from the zone it's found in. Without this, a card that started in
+  // the deck (constructed via `new Deck($cardID)` with no location/owner) keeps those blank/zero
+  // fields forever as it's array-shifted between zones in memory — SelectionMetadataMzID() then
+  // computes "their-N" for EVERY hand card of EITHER player (comparing $playerID against a stale
+  // PlayerID=0), so BotLegalActions.php's CanActivateCardForSelection() check silently rejects
+  // every materialize candidate. A single continuous CLI process never hits this naturally, unlike
+  // real play, where each request is a fresh reparse.
+  ParseGamestate($gaDir);
+  foreach ([1, 2] as $seat) {
+    $snapshot = GASnapshotChampion($seat);
+    if (!empty($snapshot['championId'])) $lastChampions[strval($seat)] = $snapshot;
+  }
+
+  $winner = intval(DecisionQueueController::GetVariable('GAMEOVER_WINNER'));
+  if ($winner !== 0) { $gameOver = true; break; }
+
+  $result = ProcessBotControllerStep(0, 'GrandArchiveSim', $gameName);
+  if (empty($result['success'])) {
+    $message = strval($result['message'] ?? 'unknown engine error');
+    $decoded = json_decode($message, true);
+    $label = is_array($decoded) && ($decoded['code'] ?? '') === 'idle_effect_stack_no_progress'
+      ? 'bot does not leave an idle Effect Stack unresolved'
+      : 'bot step succeeds';
+    BotTestCheck($checks, $label, false, "step {$steps}: " . $message);
+    break;
+  }
+  // ProcessBotControllerStep() is normally reached through EngineActionRunner mode 10017, whose
+  // outer action persists controller-owned work (for example ResumeIdleEffectStackIfNeeded()) when
+  // no nested gameplay action ran. This harness calls the controller directly, so mirror that one
+  // outer write before the next loop's ParseGamestate() would otherwise restore stale disk state.
+  if (!empty($result['writeGamestate'])) WriteGamestate($gaDir);
+  if (empty($result['applied'])) {
+    $consecutiveNoOps++;
+    if ($consecutiveNoOps >= $maxConsecutiveNoOps) { $stalled = true; break; }
+  } else {
+    $consecutiveNoOps = 0;
+  }
+
+  if ($args['verbose'] && $steps > 0 && $steps % 50 === 0) echo "[INFO] step {$steps}...\n";
+}
+
+BotTestCheck($checks, 'game reaches completion', $gameOver,
+  $gameOver ? "in {$steps} bot steps, winner=P{$winner}"
+    : ($stalled ? "stalled after {$consecutiveNoOps} consecutive no-op steps (around step {$steps})"
+                : "hit --max-steps={$args['maxSteps']} without a winner"));
+
+if (!$gameOver) BotTestStallDiagnostic($gaDir, $gameName, $stalled ? 'stall' : 'timeout');
+
+BotTestCheck($checks, 'no unrecognized decision-type gaps', empty($GLOBALS['GABotUnrecognizedDecisions']),
+  empty($GLOBALS['GABotUnrecognizedDecisions']) ? '' : json_encode($GLOBALS['GABotUnrecognizedDecisions']));
+
+// ── Telemetry / logging assertions (in-process — the same globals Telemetry.php's accumulator
+// writes to, no separate debug-endpoint request needed). ───────────────────────────────────────
+ParseGamestate($gaDir); // refresh once more: the loop's last executed step wrote state but never reparsed it
+$detail = GACaptureCurrentGameDetail();
+foreach ([1, 2] as $seat) {
+  $key = strval($seat);
+  if (empty($detail['champions'][$key]['championId']) && !empty($lastChampions[$key]['championId'])) {
+    $detail['champions'][$key] = $lastChampions[$key];
+    $lastTurn = null;
+    foreach (($detail['telemetry']['turns'] ?? []) as $turn) {
+      if (intval($turn['seat'] ?? 0) === $seat) $lastTurn = $turn;
+    }
+    if ($lastTurn !== null) {
+      $detail['champions'][$key]['level'] = intval($lastTurn['level'] ?? $detail['champions'][$key]['level']);
+      $detail['champions'][$key]['hp'] = intval($lastTurn['hp'] ?? 0);
+    }
+  }
+}
+$tel = $detail['telemetry'];
+
+foreach ([1, 2] as $seat) {
+  $champ = $detail['champions'][strval($seat)] ?? null;
+  // A defeated champion may already be removed by cleanup before final capture. The winner must
+  // still resolve; for the losing seat, an empty final snapshot is expected and meaningful.
+  $championPresent = !empty($champ['championId']);
+  $championExpected = !$gameOver || $seat === $winner;
+  BotTestCheck($checks, "P{$seat} champion " . ($championExpected ? 'resolved' : 'captured or defeated'),
+    $championPresent || !$championExpected, $championPresent ? $champ['championId'] : '(defeated)');
+
+  $materialized = 0; $drawn = 0;
+  foreach (($tel['cards'][strval($seat)] ?? []) as $c) {
+    $materialized += intval($c['materialized'] ?? 0);
+    $drawn += intval($c['drawn'] ?? 0) + intval($c['drawnToMemory'] ?? 0);
+  }
+  BotTestCheck($checks, "P{$seat} telemetry: cards drawn", $drawn > 0, "drawn={$drawn}");
+  BotTestCheck($checks, "P{$seat} telemetry: cards materialized", $materialized > 0, "materialized={$materialized}");
+}
+
+BotTestCheck($checks, 'telemetry: turn snapshots recorded', !empty($tel['turns']), 'count=' . count($tel['turns'] ?? []));
+BotTestCheck($checks, 'telemetry: combat events recorded', !empty($tel['combatEvents']), 'count=' . count($tel['combatEvents'] ?? []));
+
+if ($gameOver && !empty($args['payloadOut'])) {
+  $matchId = 'headless-local-' . strval($gameName);
+  $match = [
+    'matchId' => $matchId,
+    'createdAt' => time(),
+    'format' => 'bot',
+    'bestOf' => 1,
+    'winner' => $winner,
+    'wins' => ['1' => $winner === 1 ? 1 : 0, '2' => $winner === 2 ? 1 : 0],
+    'players' => [
+      '1' => ['deckLink' => ''],
+      '2' => ['deckLink' => ''],
+    ],
+  ];
+  $game = ['gameName' => strval($gameName), 'gameNumber' => 1, 'winner' => $winner, 'detail' => $detail];
+  $payload = GABuildGameResultPayload($match, $game);
+  $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+  $written = $encoded !== false && file_put_contents($args['payloadOut'], $encoded . "\n") !== false;
+  BotTestCheck($checks, 'analytics payload exported', $written, strval($args['payloadOut']));
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────────────────────────
+$failures = 0;
+foreach ($checks as [$label, $passed, $detail]) {
+  echo ($passed ? '[PASS] ' : '[FAIL] ') . $label . ($detail !== '' ? " — {$detail}" : '') . "\n";
+  if (!$passed) $failures++;
+}
+echo "[SUMMARY] Total: " . count($checks) . " | Pass: " . (count($checks) - $failures) . " | Fail: {$failures}\n";
+
+exit($failures > 0 ? 1 : 0);

--- a/GrandArchiveSim/BotController.php
+++ b/GrandArchiveSim/BotController.php
@@ -1,0 +1,226 @@
+<?php
+// GA's implementation of the shared Core/BotController.php contract (4 functions: see that file's
+// header comment), mirroring AzukiSim/Custom/GameLogic.php:830-852 and its execution block at
+// 797-803. Once these 4 functions exist, the existing client-side bot-step polling (mode 10017 in
+// Core/EngineActionRunner.php, the JS loop in Core/jsInclude.js) works for GA with no client
+// changes — this file is the entire GA-specific surface of that integration.
+
+// A gamestate hash for no-op detection (see ProcessBotControllerStep below), EXCLUDING bookkeeping
+// that mutates on EVERY write regardless of whether the attempted action had any real effect.
+// RegressionCurrentGamestateHash() alone can't be reused here — three fields were found (via
+// GrandArchiveSim/Tests/BotFixtures self-play) to change on a rejected/no-op action, each one
+// independently defeating a raw-text hash comparison and stranding the bot in an infinite loop:
+//   - updateNumber (2nd line of every serialized gamestate — RegressionConsumeGamestateLayout's own
+//     comment: "Every generated gamestate begins with currentPlayer and updateNumber"): incremented
+//     unconditionally by Core/EngineActionRunner.php whenever `$result['writeGamestate']` is true,
+//     which is the default for every call regardless of outcome.
+//   - FlashMessage (Schemas/GrandArchiveSim/GameSchema.txt): a rejected action still typically calls
+//     SetFlashMessage() with a reason ("Cannot pass while effects are pending resolution.", etc.).
+//   - the MR1: match-replay recording line: every ATTEMPTED action is appended as a frame for replay
+//     fidelity, on purpose, independent of whether it changed the game.
+function GABotComparableGamestateHash($gameName) {
+    if (!function_exists('RegressionCurrentGamestateText') || !function_exists('RegressionNormalizeNewlines')
+        || !function_exists('RegressionGamestateSchemaLayout') || !function_exists('RegressionConsumeGamestateLayout')) {
+        return null;
+    }
+    $text = RegressionCurrentGamestateText('GrandArchiveSim', $gameName);
+    if (!is_string($text)) return null;
+    $lines = explode("\n", RegressionNormalizeNewlines($text));
+    if (count($lines) > 1) unset($lines[1]); // drop updateNumber
+
+    $layout = RegressionGamestateSchemaLayout('GrandArchiveSim');
+    $blocks = [];
+    RegressionConsumeGamestateLayout($layout, $lines, $blocks);
+    foreach ($blocks as $block) {
+        if ($block['name'] !== 'FlashMessage') continue;
+        for ($i = $block['start']; $i < $block['start'] + $block['length']; $i++) unset($lines[$i]);
+    }
+    foreach ($lines as $i => $line) {
+        if (strpos($line, 'MR1:') === 0) unset($lines[$i]);
+    }
+    return hash('sha256', implode("\n", $lines));
+}
+
+function SetGABotPlayers($players) {
+    DecisionQueueController::StoreVariable("BotPlayers", NormalizeGoldfishPlayers($players));
+}
+
+function GetGABotPlayers() {
+    return NormalizeGoldfishPlayers(DecisionQueueController::GetVariable("BotPlayers"));
+}
+
+function GameBotControllerMode() {
+    return GAGameMode() === 'bot' ? 'bot' : '';
+}
+
+function GetBotControllerPlayers() {
+    if (GAGameMode() !== 'bot') return [];
+    return GetGABotPlayers();
+}
+
+// Compact, deterministic context for an Effect Stack recovery failure. Keep this independent of
+// object indexes/unique IDs so a regression fixture can compare it across fresh game runs.
+function GABotIdleEffectStackSignature() {
+    $stack = function_exists('GetLiveEffectStackEntries') ? GetLiveEffectStackEntries() : [];
+    $top = !empty($stack) ? $stack[count($stack) - 1] : null;
+    $queues = [];
+    if (function_exists('GetDecisionQueue')) {
+        foreach ([1, 2] as $seat) {
+            foreach (GetDecisionQueue($seat) as $entry) {
+                if ($entry === null || !empty($entry->removed)) continue;
+                $queues[] = [
+                    'seat' => $seat,
+                    'type' => strval($entry->Type ?? ''),
+                    'param' => strval($entry->Param ?? ''),
+                ];
+            }
+        }
+    }
+    return [
+        'cardId' => strval($top->CardID ?? ''),
+        'controller' => intval($top->Controller ?? 0),
+        'triggerType' => strval($top->TriggerType ?? ''),
+        'turnEffects' => array_values($top->TurnEffects ?? []),
+        'turnPlayer' => function_exists('GetTurnPlayer') ? intval(GetTurnPlayer()) : 0,
+        'phase' => function_exists('GetCurrentPhase') ? strval(GetCurrentPhase()) : '',
+        'queues' => $queues,
+    ];
+}
+
+// Which seat currently needs a bot move, or 0 if none. A pending DecisionQueue response always
+// takes priority (matches GABotPendingDecisionPlayer's own precedence); otherwise, if the current
+// free-play turn player is bot-controlled, that seat is pending.
+function BotControllerPendingPlayerForClient() {
+    if (GAGameMode() !== 'bot') return 0;
+    $botPlayers = GetGABotPlayers();
+    if (empty($botPlayers)) return 0;
+
+    $decisionPlayer = function_exists('GABotPendingDecisionPlayer') ? GABotPendingDecisionPlayer() : 0;
+    if ($decisionPlayer !== 0) {
+        return in_array($decisionPlayer, $botPlayers, true) ? $decisionPlayer : 0;
+    }
+
+    if (function_exists('GetCurrentPhase') && GetCurrentPhase() !== 'MAIN') return 0;
+    $turnPlayer = function_exists('GetTurnPlayer') ? intval(GetTurnPlayer()) : 0;
+    return in_array($turnPlayer, $botPlayers, true) ? $turnPlayer : 0;
+}
+
+function ProcessBotControllerStep($requestingPlayer = 0, $folderPath = '', $gameNameOverride = '') {
+    if ($folderPath !== '' && $folderPath !== 'GrandArchiveSim') {
+        return ['success' => false, 'message' => 'Bot controller does not handle this game.', 'applied' => false];
+    }
+    if (GAGameMode() !== 'bot') {
+        return ['success' => true, 'message' => '', 'applied' => false, 'retryable' => false];
+    }
+
+    global $gameName;
+    $activeGameName = $gameNameOverride !== '' ? $gameNameOverride : strval($gameName ?? '');
+    if ($activeGameName === '') {
+        return ['success' => false, 'message' => 'Bot controller game is not loaded.', 'applied' => false, 'retryable' => false];
+    }
+
+    $pendingPlayer = BotControllerPendingPlayerForClient();
+    // A card can be left on the Effect Stack after engine-owned static queue work completes.
+    // In that state there is deliberately no player decision yet, but normal MAIN actions (most
+    // visibly Pass) are illegal until the stack-priority window is restored. The standard GA
+    // recovery helper queues/resolves that window; persist this outer mode-10017 action and let
+    // the next poll answer any newly-created player decision.
+    $idleStack = function_exists('GetLiveEffectStackEntries') ? GetLiveEffectStackEntries() : [];
+    if (function_exists('GABotPendingDecisionPlayer') && GABotPendingDecisionPlayer() === 0 && !empty($idleStack)) {
+        $beforeSignature = GABotIdleEffectStackSignature();
+        $resumed = function_exists('ResumeIdleEffectStackIfNeeded') && ResumeIdleEffectStackIfNeeded();
+        $afterSignature = GABotIdleEffectStackSignature();
+        // ResumeIdleEffectStackIfNeeded mutates the loaded in-memory state. The outer mode-10017
+        // action performs the first write, so a disk-backed gamestate hash is intentionally still
+        // unchanged here. Compare the semantic live stack/queue signatures instead.
+        if ($resumed && $beforeSignature !== $afterSignature) {
+            return [
+                'success' => true,
+                'message' => 'Resumed pending Effect Stack resolution.',
+                'writeGamestate' => true,
+                'updateCache' => true,
+                'applied' => true,
+                'retryable' => true,
+            ];
+        }
+        $failure = ['code' => 'idle_effect_stack_no_progress', 'before' => $beforeSignature,
+            'after' => $afterSignature, 'resumeAttempted' => $resumed];
+        error_log('GABot: ' . json_encode($failure));
+        return [
+            'success' => false,
+            'message' => json_encode($failure),
+            'writeGamestate' => false,
+            'updateCache' => false,
+            'applied' => false,
+            'retryable' => false,
+        ];
+    }
+    $pendingPlayer = BotControllerPendingPlayerForClient();
+    if ($pendingPlayer === 0) {
+        return ['success' => true, 'message' => 'No bot action is currently pending.', 'applied' => false, 'retryable' => false];
+    }
+
+    global $playerID;
+    $savedPlayerID = $playerID;
+    $playerID = $pendingPlayer;
+
+    $legal = GABotLegalActions($activeGameName, $pendingPlayer);
+    $actingPlayer = intval($legal['playerID'] ?? 0);
+    if ($actingPlayer !== $pendingPlayer) {
+        $playerID = $savedPlayerID;
+        return ['success' => true, 'message' => "No bot action is pending for player $pendingPlayer.", 'applied' => false];
+    }
+
+    $actions = is_array($legal['actions'] ?? null) ? $legal['actions'] : [];
+    if (empty($actions)) {
+        $playerID = $savedPlayerID;
+        return ['success' => true, 'message' => 'No legal bot actions are available.', 'applied' => false];
+    }
+
+    // The enumerator's pre-filters are cheap and can't fully replicate the engine's own legality
+    // chain (BeginCombatPhase in particular IS that chain — see BotLegalActions.php's comment), so
+    // the chooser's top pick can turn out to be illegal for reasons only discoverable by actually
+    // attempting it. Retry with that candidate excluded rather than returning a single no-op and
+    // trusting the caller to try something different next poll — a real poller (and the self-play
+    // test harness) re-invokes the SAME chooser against the SAME unchanged legal-action set, so
+    // without this loop a persistently-illegal-but-cheaply-legal-looking candidate (e.g. a stale
+    // field index) gets re-chosen and re-rejected forever. Bounded by the action list itself: the
+    // always-present end-turn Pass action is never excluded and is never a no-op (it always
+    // advances something), so this loop is guaranteed to terminate with an applied action.
+    $remaining = $actions;
+    $result = null; $cleanAction = null; $noOp = true;
+    while (!empty($remaining)) {
+        $action = GABotChooseAction($remaining, $legal);
+        if ($action === null) break;
+        $cleanAction = [
+            'playerID' => intval($action['playerID'] ?? $pendingPlayer),
+            'mode' => intval($action['mode'] ?? 0),
+            'cardID' => strval($action['cardID'] ?? ''),
+            'buttonInput' => strval($action['buttonInput'] ?? ''),
+            'chkInput' => $action['chkInput'] ?? [],
+            'inputText' => strval($action['inputText'] ?? ''),
+        ];
+        // No-op detection (same primitive Azuki's bot uses, AzukiSim/Custom/GameLogic.php:796,811-819):
+        // comparing a gamestate hash before/after is what actually distinguishes "the action did
+        // something" from "it quietly no-op'd".
+        $beforeHash = GABotComparableGamestateHash($activeGameName);
+        $result = EngineExecuteLoadedAction($cleanAction, 'GrandArchiveSim', $activeGameName, ['updateCache' => true]);
+        $afterHash = GABotComparableGamestateHash($activeGameName);
+        $noOp = ($beforeHash !== null && $afterHash !== null && $beforeHash === $afterHash);
+        if (!$noOp) break;
+        error_log("GABot: action produced no gamestate change for seat $pendingPlayer (mode={$cleanAction['mode']}, cardID={$cleanAction['cardID']}) — excluding and retrying.");
+        $remaining = array_values(array_filter($remaining, fn($a) => strval($a['cardID'] ?? '') !== $cleanAction['cardID']));
+    }
+    $playerID = $savedPlayerID;
+    if ($cleanAction === null) {
+        return ['success' => true, 'message' => 'Bot chooser returned no action.', 'applied' => false];
+    }
+    return [
+        'success' => !empty($result['success']),
+        'message' => strval($result['message'] ?? ''),
+        'writeGamestate' => !empty($result['writeGamestate']),
+        'updateCache' => !empty($result['updateCache']),
+        'applied' => !$noOp,
+        'retryable' => true,
+    ];
+}

--- a/GrandArchiveSim/BotHeuristic.php
+++ b/GrandArchiveSim/BotHeuristic.php
@@ -1,0 +1,152 @@
+<?php
+// The swappable "chooser" half of the GA bot seam:
+//   GABotLegalActions() -> chooser($actions, $legal) -> one action -> EngineExecuteLoadedAction()
+// This file provides the default rule-based chooser. A future model-backed chooser (mirroring
+// AzukiRlBotChooseAction's checkpoint-lookup pattern) can be added and registered under a new
+// profile name without touching enumeration (BotLegalActions.php) or execution (BotController.php).
+
+if (!isset($GLOBALS['GABotChoosers'])) {
+    $GLOBALS['GABotChoosers'] = [];
+}
+
+function GABotRegisterChooser($profileName, callable $fn) {
+    $GLOBALS['GABotChoosers'][strval($profileName)] = $fn;
+}
+
+// Per-game chooser selection, mirroring Azuki's per-seat AzukiRlBotProfile DQ variable. Defaults
+// to 'heuristic' — the only profile registered today.
+function GABotActiveChooserProfile() {
+    $value = class_exists('DecisionQueueController') ? DecisionQueueController::GetVariable('GABotProfile') : null;
+    return ($value !== null && $value !== '') ? strval($value) : 'heuristic';
+}
+
+function GABotChooseAction(array $actions, array $legal) {
+    if (empty($actions)) return null;
+    $profile = GABotActiveChooserProfile();
+    $chooser = $GLOBALS['GABotChoosers'][$profile] ?? $GLOBALS['GABotChoosers']['heuristic'] ?? null;
+    if ($chooser === null) return $actions[0];
+    return call_user_func($chooser, $actions, $legal);
+}
+
+// Rough total attack power available to $player this turn — sum of CurrentPower across field
+// slots the enumerator offered as attack candidates (mode 10002, "myField-" cardID).
+function GABotEstimateAttackPower($player, array $actions) {
+    $total = 0;
+    foreach ($actions as $a) {
+        if (($a['mode'] ?? 0) != 10002) continue;
+        $cardID = strval($a['cardID'] ?? '');
+        if (strpos($cardID, 'myField-') !== 0) continue;
+        $idx = intval(substr($cardID, strlen('myField-')));
+        $field = GetField($player);
+        $obj = $field[$idx] ?? null;
+        if ($obj === null) continue;
+        $power = function_exists('ObjectCurrentPower') ? ObjectCurrentPower($obj) : intval($obj->CurrentPower ?? 0);
+        if ($power > 0) $total += $power;
+    }
+    return $total;
+}
+
+function GABotOpponentChampionHP($player) {
+    $opponent = ($player == 1) ? 2 : 1;
+    if (!function_exists('FindChampionMZ') || !function_exists('GetZoneObject')) return null;
+    // FindChampionMZ/GetZoneObject resolve "myField"/"theirField" relative to the ambient
+    // $playerID perspective global, not the $player argument — set it for this lookup regardless
+    // of what the caller left it as (see the identical issue found in GACaptureCurrentGameDetail).
+    global $playerID;
+    $savedPlayerID = $playerID;
+    $playerID = $player;
+    $mz = FindChampionMZ($opponent);
+    $obj = $mz !== null ? GetZoneObject($mz) : null;
+    $playerID = $savedPlayerID;
+    if ($obj === null) return null;
+    $hp = function_exists('ObjectCurrentHP') ? ObjectCurrentHP($obj) : intval($obj->CurrentHP ?? 0);
+    return max(0, intval($hp) - intval($obj->Damage ?? 0));
+}
+
+function GABotScoreAttackAction($player, array $action) {
+    $cardID = strval($action['cardID'] ?? '');
+    if (!preg_match('/^myField-(\d+)/', $cardID, $m)) return PHP_INT_MIN;
+    $attacker = GetField($player)[intval($m[1])] ?? null;
+    if ($attacker === null || !empty($attacker->removed)) return PHP_INT_MIN;
+
+    $power = max(0, intval(function_exists('ObjectCurrentPower') ? ObjectCurrentPower($attacker) : ($attacker->CurrentPower ?? 0)));
+    $hp = max(0, intval(function_exists('ObjectCurrentHP') ? ObjectCurrentHP($attacker) : ($attacker->CurrentHP ?? 0)) - intval($attacker->Damage ?? 0));
+    $opponent = ($player === 1) ? 2 : 1;
+    $oppChampPower = 0;
+    $oppChampHP = GABotOpponentChampionHP($player);
+    foreach (GetField($opponent) as $obj) {
+        if ($obj === null || !empty($obj->removed) || !PropertyContains(EffectiveCardType($obj), 'CHAMPION')) continue;
+        $oppChampPower = max($oppChampPower, intval(ObjectCurrentPower($obj)));
+    }
+
+    // Face pressure is valuable, with a large bonus for a plausible lethal. Penalize attacks
+    // that likely trade away the attacker into the opposing champion, while still allowing
+    // lethal attacks and high-power pressure to override that conservatism.
+    $score = $power * 10;
+    if ($oppChampHP !== null) {
+        if ($power >= $oppChampHP && $power > 0) $score += 10000;
+        else $score += min($power, $oppChampHP) * 4;
+    }
+    if ($oppChampPower > 0 && $hp <= $oppChampPower) $score -= $power * 7;
+    if (PropertyContains(EffectiveCardType($attacker), 'CHAMPION')) $score += 3;
+    return $score;
+}
+
+function GABotChooseActionHeuristic(array $actions, array $legal) {
+    $kind = strval($legal['kind'] ?? '');
+    $player = intval($legal['playerID'] ?? 0);
+
+    if ($kind === 'decision') {
+        // BotLegalActions.php already picked the single safe/conservative response for every
+        // decision type it recognizes (pay reserve with first hand card, decline YES/NO, decline
+        // optional choices, pick the first candidate for a required target choice) — nothing left
+        // to choose between here.
+        return $actions[0];
+    }
+
+    // Free play. Prefer materializing (developing the board) over attacking on principle — a
+    // bigger board this turn tends to matter more than a small early attack — except when an
+    // attack looks lethal right now, which always takes priority.
+    $materializeActions = array_values(array_filter($actions, fn($a) => ($a['mode'] ?? 0) == 10002 && strpos(strval($a['cardID'] ?? ''), 'myHand-') === 0));
+    $attackActions = array_values(array_filter($actions, fn($a) => ($a['mode'] ?? 0) == 10002 && strpos(strval($a['cardID'] ?? ''), 'myField-') === 0));
+    $endTurnAction = null;
+    foreach ($actions as $a) { if (($a['mode'] ?? 0) == 10001) { $endTurnAction = $a; break; } }
+
+    if (!empty($attackActions)) {
+        $oppHP = GABotOpponentChampionHP($player);
+        $potentialDamage = GABotEstimateAttackPower($player, $attackActions);
+        usort($attackActions, fn($a, $b) => GABotScoreAttackAction($player, $b) <=> GABotScoreAttackAction($player, $a));
+        if ($oppHP !== null && $potentialDamage >= $oppHP && $potentialDamage > 0) {
+            return $attackActions[0]; // go for lethal with the best individual attacker
+        }
+        // Favor a strong, survivable pressure attack over another marginal development play.
+        if (GABotScoreAttackAction($player, $attackActions[0]) >= 55) return $attackActions[0];
+    }
+
+    if (!empty($materializeActions)) {
+        // Highest-cost-first is a crude proxy for "biggest impact" — good enough for a first pass.
+        usort($materializeActions, function ($a, $b) use ($player) {
+            $costA = GABotHandCardMemoryCost($a['cardID'] ?? '', $player);
+            $costB = GABotHandCardMemoryCost($b['cardID'] ?? '', $player);
+            return $costB <=> $costA;
+        });
+        return $materializeActions[0];
+    }
+
+    if (!empty($attackActions)) {
+        return $attackActions[0];
+    }
+
+    return $endTurnAction ?? $actions[0];
+}
+
+function GABotHandCardMemoryCost($cardID, $player) {
+    // $cardID here is an mzID string like "myHand-2!FSM!"; resolve back to the underlying card.
+    if (!preg_match('/^myHand-(\d+)/', strval($cardID), $m)) return 0;
+    $hand = GetHand($player);
+    $obj = $hand[intval($m[1])] ?? null;
+    if ($obj === null || !isset($obj->CardID)) return 0;
+    return function_exists('CardMemoryCost') ? intval(CardMemoryCost($obj)) : 0;
+}
+
+GABotRegisterChooser('heuristic', 'GABotChooseActionHeuristic');

--- a/GrandArchiveSim/BotLegalActions.php
+++ b/GrandArchiveSim/BotLegalActions.php
@@ -1,0 +1,177 @@
+<?php
+// Legal-action enumeration for the GA heuristic bot. Reuses the exact functions that already
+// drive the client's card-highlight colors (CanActivateCardForSelection) and the exact function
+// that is simultaneously the check AND the action for attacks (BeginCombatPhase has no
+// side-effect-free predicate — see GABotLegalActions below). Returns raw ProcessInput.php-shaped
+// {mode, cardID, playerID} action pairs, mirroring AzukiRlBotLegalActions's shape
+// (AzukiSim/Custom/GameLogic.php:578-602) so a future model-backed chooser can consume the same
+// data a heuristic chooser does.
+
+// Whichever seat has a non-empty DecisionQueue must respond before anything else can happen —
+// mirrors AzukiPendingDecisionPlayer() gating AzukiRlBotLegalActions.
+function GABotPendingDecisionPlayer() {
+    foreach ([1, 2] as $seat) {
+        if (!function_exists('GetDecisionQueue')) return 0;
+        $dq = GetDecisionQueue($seat);
+        foreach ($dq as $entry) {
+            if ($entry !== null && empty($entry->removed)) return $seat;
+        }
+    }
+    return 0;
+}
+
+function GABotFrontDecision($seat) {
+    $dq = GetDecisionQueue($seat);
+    foreach ($dq as $entry) {
+        if ($entry !== null && empty($entry->removed)) return $entry;
+    }
+    return null;
+}
+
+function GABotChooseCombatTarget($player, array $candidates) {
+    global $playerID;
+    $savedPlayerID = $playerID;
+    $playerID = intval($player);
+    $attackerMZ = DecisionQueueController::GetVariable('CombatAttacker');
+    $attacker = $attackerMZ !== null ? GetZoneObject($attackerMZ) : null;
+    $attackPower = $attacker !== null ? max(0, intval(ObjectCurrentPower($attacker))) : 0;
+    $attackHP = $attacker !== null ? max(0, intval(ObjectCurrentHP($attacker)) - intval($attacker->Damage ?? 0)) : 0;
+    $best = null; $bestScore = PHP_INT_MIN;
+    foreach ($candidates as $candidate) {
+        $target = GetZoneObject($candidate);
+        if ($target === null || !empty($target->removed)) continue;
+        $type = EffectiveCardType($target);
+        $targetPower = max(0, intval(ObjectCurrentPower($target)));
+        $targetHP = max(0, intval(ObjectCurrentHP($target)) - intval($target->Damage ?? 0));
+        $score = 0;
+        if (PropertyContains($type, 'CHAMPION')) {
+            $score = 500 + $attackPower * 8;
+            if ($attackPower >= $targetHP && $attackPower > 0) $score += 10000;
+        } else {
+            // Favor killing a unit without losing the attacker; avoid suicidal trades unless
+            // the target is substantially more powerful.
+            if ($attackPower >= $targetHP && $attackPower > 0) $score += 180;
+            $score += $targetPower * 10;
+            if ($attackHP > $targetPower) $score += 80;
+            else $score -= max(0, $attackPower * 5 - $targetPower * 2);
+        }
+        if ($score > $bestScore) { $bestScore = $score; $best = $candidate; }
+    }
+    $playerID = $savedPlayerID;
+    return $best ?? (reset($candidates) ?: 'PASS');
+}
+
+// {playerID, kind: 'decision'|'free-play', decisionType?, actions: [{playerID, mode, cardID}]}
+function GABotLegalActions($gameName, $player) {
+    $pending = GABotPendingDecisionPlayer();
+    if ($pending !== 0) {
+        $front = GABotFrontDecision($pending);
+        $type = $front !== null ? strval($front->Type ?? '') : '';
+        $param = $front !== null ? strval($front->Param ?? '') : '';
+        $actions = [];
+        if ($type === 'MZCHOOSE' && $param === 'myHand') {
+            // Reserve-cost payment: pay with whatever is currently first in hand (the same rule
+            // used manually throughout the telemetry-verification session).
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => 'myHand-0'];
+        } elseif ($type === 'MZCHOOSE' && strpos($param, '&') !== false) {
+            // Required choice among several listed candidates (e.g. "Choose_attack_target":
+            // Param="theirField-0&theirField-1") — not a May-choose, so PASS is not a valid
+            // response. Pick the first listed candidate.
+            $candidates = array_filter(explode('&', $param));
+            $tooltip = strval($front->Tooltip ?? '');
+            $choice = stripos($tooltip, 'attack_target') !== false
+                ? GABotChooseCombatTarget($pending, array_values($candidates))
+                : reset($candidates);
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => $choice !== false ? $choice : 'PASS'];
+        } elseif ($type === 'MZCHOOSE' && preg_match('/^(my|their)[A-Za-z]+-\d+$/', $param)) {
+            // Required choice with exactly one candidate, named directly in Param (e.g. the
+            // pregame "Reveal your starting Lv 0 champion" decision: Param="myMaterial-11") — the
+            // only legal response IS that mzID, so echo it back rather than treating this like the
+            // reserve-payment or opportunity-window cases below.
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => $param];
+        } elseif ($type === 'YESNO') {
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => 'NO'];
+        } elseif ($type === 'NAMECARD') {
+            // Use the same deterministic chooser as goldfish automation: prefer an explicit
+            // preview candidate, then a card visible in the bot's own zones. NAMECARD expects
+            // the display name as the decision response, not an mzID.
+            $name = function_exists('GoldfishChooseCardName')
+                ? GoldfishChooseCardName($pending, $param)
+                : 'Fireball';
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => $name];
+        } elseif ($type === 'MZREARRANGE') {
+            // The engine's rearrange protocol already encodes the complete desired ordering.
+            // Preserve it verbatim, matching GoldfishResolveDecisionInput().
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => $param];
+        } elseif ($type === 'MZMULTICHOOSE') {
+            // Param: min|max|candidateMzIDs. Meet the required minimum with the first legal
+            // candidates; decline cleanly when the choice is optional.
+            $parts = explode('|', $param, 3);
+            $min = max(0, intval($parts[0] ?? 0));
+            $candidates = array_values(array_filter(explode('&', strval($parts[2] ?? ''))));
+            if ($min === 0) {
+                $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => '-'];
+            } elseif (count($candidates) >= $min) {
+                $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => implode('&', array_slice($candidates, 0, $min))];
+            } else {
+                $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => '-'];
+            }
+        } elseif (in_array($type, ['MZMODAL', 'NUMBERCHOOSE', 'TWOSIDEDSLIDER', 'MZSPLITASSIGN', 'CHOOSEZONE', 'ICONCHOICE'], true)) {
+            // Goldfish already has a deterministic, engine-compatible response encoder for these
+            // non-card decision formats. Reuse it so bot and goldfish agree on wire syntax.
+            $input = function_exists('GoldfishResolveDecisionInput') ? GoldfishResolveDecisionInput($pending, $front) : null;
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => $input !== null ? $input : '-'];
+        } elseif ($type === 'MZMAYCHOOSE' || $type === 'MZCHOOSE') {
+            // Opportunity windows and other optional/May choices: decline. Any other MZCHOOSE
+            // shape we don't specifically recognize falls back to PASS too, rather than guessing
+            // a target — an unrecognized required choice will surface as a stalled decision queue,
+            // which is the safe failure mode (see the error_log below).
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => 'PASS'];
+        } else {
+            $actions[] = ['playerID' => $pending, 'mode' => 100, 'cardID' => 'PASS'];
+            error_log("GABot: unrecognized decision type '$type' (param='$param') for seat $pending — defaulting to PASS.");
+            // Structured mirror of the error_log above — lets callers (the self-play test harness in
+            // particular) assert "no unhandled decision gap occurred" without scraping log text.
+            $GLOBALS['GABotUnrecognizedDecisions'][] = ['type' => $type, 'param' => $param, 'seat' => $pending];
+        }
+        return ['playerID' => $pending, 'kind' => 'decision', 'decisionType' => $type, 'actions' => $actions];
+    }
+
+    // Free play: legal hand materializes + legal attack candidates + always-available end turn.
+    $actions = [];
+    global $playerID;
+    $savedPlayerID = $playerID;
+    $playerID = $player; // CanActivateCardForSelection's mzID derivation depends on this perspective global
+
+    $hand = GetHand($player);
+    foreach ($hand as $i => $obj) {
+        if ($obj === null || !empty($obj->removed)) continue;
+        if (function_exists('CanActivateCardForSelection') && CanActivateCardForSelection($player, $obj, false)) {
+            $actions[] = ['playerID' => $player, 'mode' => 10002, 'cardID' => "myHand-$i!FSM!"];
+        }
+    }
+
+    $field = GetField($player);
+    foreach ($field as $i => $obj) {
+        if ($obj === null || !empty($obj->removed)) continue;
+        if (intval($obj->Status ?? 0) !== 2) continue; // must be awake/rested-ready
+        $cardType = function_exists('EffectiveCardType') ? EffectiveCardType($obj) : CardType($obj->CardID);
+        if (!PropertyContains($cardType, 'ALLY') && !PropertyContains($cardType, 'CHAMPION')) continue;
+        // Power > 0 is one of BeginCombatPhase's own checks and, unlike the rest of that chain
+        // (weapon taxes, valid-target search, etc.), is a cheap, side-effect-free read — worth
+        // pre-filtering here. Without it, a 0-power champion with no weapon gets offered every
+        // step, BeginCombatPhase silently rejects it every time, and the bot loops forever
+        // re-choosing the same doomed attack instead of ever reaching materialize/end-turn.
+        // This does mean a 0-power unit that could still attack via an equipped weapon is missed
+        // — an accepted gap, not a correctness issue (BeginCombatPhase remains the real authority
+        // for every candidate that DOES pass this filter).
+        $power = function_exists('ObjectCurrentPower') ? intval(ObjectCurrentPower($obj)) : 0;
+        if ($power <= 0) continue;
+        $actions[] = ['playerID' => $player, 'mode' => 10002, 'cardID' => "myField-$i!FSM!"];
+    }
+
+    $playerID = $savedPlayerID;
+
+    $actions[] = ['playerID' => $player, 'mode' => 10001, 'cardID' => 'myHealth-0!CustomInput!Pass'];
+    return ['playerID' => $player, 'kind' => 'free-play', 'actions' => $actions];
+}

--- a/GrandArchiveSim/CreateGame.php
+++ b/GrandArchiveSim/CreateGame.php
@@ -52,11 +52,11 @@ function GASetupGame($lobby, $opts = []) {
     WriteGamestate(__DIR__ . "/");
     ParseGamestate(__DIR__ . "/");
 
-    // Persist the game mode (goldfish/hotseat) so the UI/mode checks can read it (GAGameMode()).
+    // Persist the game mode (goldfish/hotseat/bot) so the UI/mode checks can read it (GAGameMode()).
     $gaMode = '';
     if (isset($lobby->format)) {
         $f = strtolower((string)$lobby->format);
-        if ($f === 'goldfish' || $f === 'hotseat') $gaMode = $f;
+        if ($f === 'goldfish' || $f === 'hotseat' || $f === 'bot') $gaMode = $f;
     }
     if ($gaMode !== '') DecisionQueueController::StoreVariable("GameMode", $gaMode);
 
@@ -71,7 +71,23 @@ function GASetupGame($lobby, $opts = []) {
         SetGoldfishPlayers($goldfishPlayers);
     }
 
+    // Bot-controlled seats (self-play testing) — unlike goldfishPlayers, these seats still get a
+    // real deck below (they're just not in $goldfishPlayers, so LoadPlayer runs normally for them).
+    $botPlayers = [];
+    if(isset($lobby->botPlayers) && is_array($lobby->botPlayers)) {
+        foreach($lobby->botPlayers as $botPlayer) {
+            $playerNum = intval($botPlayer);
+            if($playerNum > 0) $botPlayers[] = $playerNum;
+        }
+    }
+    if(function_exists('SetGABotPlayers')) {
+        SetGABotPlayers($botPlayers);
+    }
+
     $playerCounter = 1;
+    // Production games retain cryptographic deck shuffles. Headless regression callers may opt
+    // into EngineShuffle's persisted deterministic stream for reproducible fixtures.
+    $useStrongShuffleEntropy = empty($opts['deterministicShuffle']);
     foreach ($lobby->players as $player) {
         $player->setGamePlayerID($playerCounter);
         $injected = $opts['resolvedDecks'][$playerCounter] ?? null;
@@ -81,9 +97,9 @@ function GASetupGame($lobby, $opts = []) {
             // so the dummy still gets a single Lv0 champion (Spirit of Fire) and no main deck.
             LoadEmptyGoldfishLoadout($playerCounter);
         } else if (is_array($injected)) {
-            LoadResolvedDeck($playerCounter, $injected);   // Match system: pre-resolved (+ sideboarded) deck
+            LoadResolvedDeck($playerCounter, $injected, $useStrongShuffleEntropy);   // Match system: pre-resolved (+ sideboarded) deck
         } else {
-            LoadPlayer($playerCounter, $player->getDeckLink(), $player->getPreconstructedDeck());
+            LoadPlayer($playerCounter, $player->getDeckLink(), $player->getPreconstructedDeck(), $useStrongShuffleEntropy);
         }
         ++$playerCounter;
     }
@@ -129,15 +145,15 @@ if (isset($lobby) && is_object($lobby)) {
 
 // Load an already-resolved deck (Match system passes pre-resolved / sideboarded decks). Mirrors the
 // resolved-deck path of LoadPlayer. The sideboard is NOT placed on the field — it lives in the Match.
-function LoadResolvedDeck($playerID, array $resolved) {
+function LoadResolvedDeck($playerID, array $resolved, $useStrongShuffleEntropy = true) {
     $gameDeck = &GetDeck($playerID);
     $material = &GetMaterial($playerID);
     foreach (($resolved['material'] ?? []) as $cardID) { array_push($material, new Material($cardID)); }
     foreach (($resolved['mainDeck'] ?? []) as $cardID) { array_push($gameDeck, new Deck($cardID)); }
-    EngineShuffle($gameDeck, true);
+    EngineShuffle($gameDeck, $useStrongShuffleEntropy);
 }
 
-function LoadPlayer($playerID, $deckLink, $preconstructedDeck = '') {
+function LoadPlayer($playerID, $deckLink, $preconstructedDeck = '', $useStrongShuffleEntropy = true) {
     // For now, ignore deckLink and use the preconstructed deck
     // When preconstructedDeck is "Refractory" or empty, use the default deck
     $gameDeck = &GetDeck($playerID);
@@ -155,7 +171,7 @@ function LoadPlayer($playerID, $deckLink, $preconstructedDeck = '') {
             if (!empty($resolved['unresolved'])) {
                 error_log("Free-text deck import: unresolved cards for player $playerID: " . implode(', ', $resolved['unresolved']));
             }
-            EngineShuffle($gameDeck, true);
+            EngineShuffle($gameDeck, $useStrongShuffleEntropy);
             return;
         }
 

--- a/GrandArchiveSim/Custom/CombatLogic.php
+++ b/GrandArchiveSim/Custom/CombatLogic.php
@@ -2856,6 +2856,25 @@ function FinalizeAttackDeclaration($attackerPlayer) {
         DealChampionDamage($defenderPlayer, 2);
     }
 
+    // Telemetry: log the attack now that attacker/target/weapon are all resolved, even though
+    // damage hasn't been dealt yet (a fully-prevented or retargeted attack still counts as one).
+    if(function_exists('GATelemetryLogCombatEvent')) {
+        $atkObj = GetZoneObject($attackerMZ);
+        $tgtObj = GetZoneObject($targetMZ);
+        $weaponMZ = GetCombatWeapon();
+        $weaponObj = $weaponMZ !== null ? GetZoneObject($weaponMZ) : null;
+        GATelemetryLogCombatEvent([
+            'type' => 'attack_initiated',
+            'turn' => function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0,
+            'attackerSeat' => intval($attackerPlayer),
+            'attackerCardId' => $atkObj !== null ? strval($atkObj->CardID) : '',
+            'targetSeat' => ($tgtObj !== null && isset($tgtObj->Controller)) ? intval($tgtObj->Controller) : (intval($attackerPlayer) == 1 ? 2 : 1),
+            'targetCardId' => $tgtObj !== null ? strval($tgtObj->CardID) : '',
+            'weaponCardId' => $weaponObj !== null ? strval($weaponObj->CardID) : null,
+            'cleave' => DecisionQueueController::GetVariable("CombatIsCleave") === "1",
+        ]);
+    }
+
     // Grant Opportunity window before damage step (turn player gets priority first)
     $turnPlayer = GetTurnPlayer();
     GrantOpportunityWindow($turnPlayer, "CombatDealDamage", $attackerPlayer, "COMBAT_DAMAGE");
@@ -3692,7 +3711,25 @@ function OnDealDamage($player, $source, $target, $amount, $skipAssassinsMantlePr
                 RemoveCounters($targetController, $target, "durability", $toRemove);
             }
             RecordTrackedCombatDamageAmount($source, $target, $amount);
-            if(GetCounterCount($targetObj, "durability") <= 0) {
+            $domainLethal = (GetCounterCount($targetObj, "durability") <= 0);
+            if(function_exists('GATelemetryLogCombatEvent')) {
+                $srcObj = GetZoneObject($source);
+                GATelemetryLogCombatEvent([
+                    'type' => 'damage_resolved',
+                    'turn' => function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0,
+                    'sourceSeat' => intval($player),
+                    'sourceCardId' => $srcObj !== null ? strval($srcObj->CardID) : '',
+                    'targetSeat' => intval($targetController),
+                    'targetCardId' => strval($targetObj->CardID),
+                    'amount' => intval($amount),
+                    'isCombat' => (DecisionQueueController::GetVariable("CombatAttacker") !== null),
+                    'lethal' => $domainLethal,
+                    'domain' => true,
+                ]);
+                GATelemetryBumpTurn(intval($player), 'damageDealt', intval($amount));
+                GATelemetryBumpTurn(intval($targetController), 'damageTaken', intval($amount));
+            }
+            if($domainLethal) {
                 // Keep mzID in the current combat perspective (attacker-context during combat damage),
                 // matching normal lethal resolution paths.
                 AllyDestroyed($player, $target);
@@ -4925,6 +4962,22 @@ function OnDealDamage($player, $source, $target, $amount, $skipAssassinsMantlePr
     RadiantOriginGuardianTrigger($source, $amount);
 
     $currentHp = ObjectCurrentHP($targetObj);
+    if(function_exists('GATelemetryLogCombatEvent')) {
+        $sourceInfoTel = ResolveDamageSourceCardInfo($source, $player);
+        GATelemetryLogCombatEvent([
+            'type' => 'damage_resolved',
+            'turn' => function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0,
+            'sourceSeat' => intval($sourceInfoTel['controller'] ?? $player),
+            'sourceCardId' => strval($sourceInfoTel['cardID'] ?? ''),
+            'targetSeat' => intval($targetObj->Controller ?? $player),
+            'targetCardId' => strval($targetObj->CardID),
+            'amount' => intval($amount),
+            'isCombat' => (bool)$isCombat,
+            'lethal' => ($targetObj->Damage >= $currentHp),
+        ]);
+        GATelemetryBumpTurn(intval($sourceInfoTel['controller'] ?? $player), 'damageDealt', intval($amount));
+        GATelemetryBumpTurn(intval($targetObj->Controller ?? $player), 'damageTaken', intval($amount));
+    }
     if($targetObj->Damage >= $currentHp) {
         // If we're in combat context, record that a kill occurred from combat damage.
         // This is checked by combat handlers to fire OnKillTrigger BEFORE OnHitTrigger.
@@ -4962,7 +5015,25 @@ function DealUnpreventableDamage($player, $source, $target, $amount) {
                 RemoveCounters($targetController, $target, "durability", $toRemove);
             }
             RecordTrackedCombatDamageAmount($source, $target, $amount);
-            if(GetCounterCount($targetObj, "durability") <= 0) {
+            $domainLethal = (GetCounterCount($targetObj, "durability") <= 0);
+            if(function_exists('GATelemetryLogCombatEvent')) {
+                $srcObj = GetZoneObject($source);
+                GATelemetryLogCombatEvent([
+                    'type' => 'damage_resolved',
+                    'turn' => function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0,
+                    'sourceSeat' => intval($player),
+                    'sourceCardId' => $srcObj !== null ? strval($srcObj->CardID) : '',
+                    'targetSeat' => intval($targetController),
+                    'targetCardId' => strval($targetObj->CardID),
+                    'amount' => intval($amount),
+                    'isCombat' => (DecisionQueueController::GetVariable("CombatAttacker") !== null),
+                    'lethal' => $domainLethal,
+                    'domain' => true,
+                ]);
+                GATelemetryBumpTurn(intval($player), 'damageDealt', intval($amount));
+                GATelemetryBumpTurn(intval($targetController), 'damageTaken', intval($amount));
+            }
+            if($domainLethal) {
                 // Keep mzID in the current combat perspective (attacker-context during combat damage),
                 // matching normal lethal resolution paths.
                 AllyDestroyed($player, $target);
@@ -5126,6 +5197,22 @@ function DealUnpreventableDamage($player, $source, $target, $amount) {
     RadiantOriginGuardianTrigger($source, $amount);
 
     $currentHp = ObjectCurrentHP($targetObj);
+    if(function_exists('GATelemetryLogCombatEvent')) {
+        $sourceInfoTel = ResolveDamageSourceCardInfo($source, $player);
+        GATelemetryLogCombatEvent([
+            'type' => 'damage_resolved',
+            'turn' => function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0,
+            'sourceSeat' => intval($sourceInfoTel['controller'] ?? $player),
+            'sourceCardId' => strval($sourceInfoTel['cardID'] ?? ''),
+            'targetSeat' => intval($targetObj->Controller ?? $player),
+            'targetCardId' => strval($targetObj->CardID),
+            'amount' => intval($amount),
+            'isCombat' => !$isNonCombat,
+            'lethal' => ($targetObj->Damage >= $currentHp),
+        ]);
+        GATelemetryBumpTurn(intval($sourceInfoTel['controller'] ?? $player), 'damageDealt', intval($amount));
+        GATelemetryBumpTurn(intval($targetObj->Controller ?? $player), 'damageTaken', intval($amount));
+    }
     if($targetObj->Damage >= $currentHp) {
         // If we're in combat context, record that a kill occurred from combat damage.
         $combatAttacker = DecisionQueueController::GetVariable("CombatAttacker");

--- a/GrandArchiveSim/Custom/GameLogic.php
+++ b/GrandArchiveSim/Custom/GameLogic.php
@@ -5,6 +5,10 @@ $customDQHandlers = [];
 $_computingPowerLifeSwap = false;
 
 include_once __DIR__ . '/../../Core/ShortcutPreferences.php';
+include_once __DIR__ . '/../Telemetry.php';
+include_once __DIR__ . '/../BotLegalActions.php';
+include_once __DIR__ . '/../BotHeuristic.php';
+include_once __DIR__ . '/../BotController.php';
 include_once __DIR__ . '/CardLogic.php';
 include_once __DIR__ . '/CombatLogic.php';
 include_once __DIR__ . '/OpportunityLogic.php';
@@ -41,7 +45,7 @@ function IsGoldfishPlayer($player) {
 // Returns 'goldfish', 'hotseat', or '' for a normal 2-player game.
 function GAGameMode(): string {
     $m = DecisionQueueController::GetVariable("GameMode");
-    return in_array($m, ['goldfish', 'hotseat'], true) ? $m : '';
+    return in_array($m, ['goldfish', 'hotseat', 'bot'], true) ? $m : '';
 }
 
 function GoldfishDecisionQueueSignature($player) {
@@ -4545,6 +4549,10 @@ function OnCardReserved($player, $mzCard, $statsContext = "ACTION") {
             IncrementMacroGameIndexCard("ReserveActionCommitted", $player, $reservedObj->CardID);
         }
     }
+    if($reservedObj !== null && isset($reservedObj->CardID) && function_exists('GATelemetryBumpCard')) {
+        GATelemetryBumpCard($player, $reservedObj->CardID, 'reserved');
+        GATelemetryBumpTurn($player, 'reserveSpent');
+    }
     return MZMove($player, $mzCard, "myMemory");
 }
 
@@ -6894,6 +6902,13 @@ function MoveEffectStackCardToField($player, $mzCard) {
     $obj = MZMove($player, $mzCard, "myField");
     DecisionQueueController::StoreVariable("EffectStackEnterCardID", "");
     DecisionQueueController::StoreVariable("EffectStackEnterController", "");
+    // Telemetry: the real "a permanent entered the field" chokepoint for cards played from hand
+    // (they resolve off the effect stack here) — DoMaterialize's own hook (MaterializeLogic.php)
+    // covers the separate from-material-zone / champion-lineage path; the two never overlap.
+    if($cardID !== "" && function_exists('GATelemetryBumpCard')) {
+        GATelemetryBumpCard($player, $cardID, 'materialized');
+        GATelemetryBumpTurn($player, 'cardsPlayed');
+    }
     return $obj;
 }
 
@@ -9679,6 +9694,8 @@ function EndPhase() {
     $savedPlayerID = $playerID;
     // Normalize my/their lookups to the active turn player's perspective for end-phase resolution.
     $playerID = $turnPlayer;
+
+    if(function_exists('GATelemetrySnapshotTurn')) GATelemetrySnapshotTurn($turnPlayer, $currentTurn);
 
     // Clear any remaining intent cards (unused attack cards) to graveyard
     ClearIntent($turnPlayer);
@@ -13407,6 +13424,7 @@ function DoDrawCard($player, $amount=1) {
         }
         $card = array_shift($zone);
         array_push($hand, $card);
+        if(function_exists('GATelemetryBumpCard') && isset($card->CardID)) GATelemetryBumpCard($player, $card->CardID, 'drawn');
 
         // Track per-card draw count for this turn
         $_ti = json_decode(GetMacroTurnIndex() ?: '{}', true) ?: [];
@@ -13456,6 +13474,7 @@ function DrawIntoMemory($player, $amount=1) {
         }
         $card = array_shift($zone);
         array_push($memory, $card);
+        if(function_exists('GATelemetryBumpCard') && isset($card->CardID)) GATelemetryBumpCard($player, $card->CardID, 'drawnToMemory');
     }
 }
 
@@ -14627,6 +14646,7 @@ function DoDiscardCard($player, $mzCard) {
 
 function OnDiscardCard($player, $discardedCardID) {
     if($discardedCardID === "") return;
+    if(function_exists('GATelemetryBumpCard')) GATelemetryBumpCard($player, $discardedCardID, 'discarded');
     DecisionQueueController::StoreVariable("discardedCardID", $discardedCardID);
     global $discardCardAbilities;
     if(!isset($discardCardAbilities) || !is_array($discardCardAbilities)) {
@@ -14760,6 +14780,7 @@ $customDQHandlers["AbilityActivated"] = function($player, $param, $lastResult) {
     if(isset($activateAbilityAbilities[$abilityKey])) {
         $activateAbilityAbilities[$abilityKey]($player);
     }
+    if(function_exists('GATelemetryBumpCard')) GATelemetryBumpCard($player, $cardID, 'activated');
     TriggerDuchessThornesCardistry($player, DecisionQueueController::GetVariable("mzID"), $cardID);
     TriggerNightmareCoilPunish($player);
     // Enhance Potency: fire any copy after ability decisions (block 1) but before AbilityOpportunity (block 200)
@@ -14777,6 +14798,7 @@ $customDQHandlers["HandAbilityActivated"] = function($player, $param, $lastResul
     if(isset($handActivatedAbilityAbilities[$abilityKey])) {
         $handActivatedAbilityAbilities[$abilityKey]($player);
     }
+    if(function_exists('GATelemetryBumpCard')) GATelemetryBumpCard($player, $cardID, 'activated');
     TriggerNightmareCoilPunish($player);
     DecisionQueueController::AddDecision($player, "CUSTOM", "CheckEnhancePotency", 99);
     DecisionQueueController::AddDecision($player, "CUSTOM", "AbilityOpportunity", 200);
@@ -17754,6 +17776,9 @@ function RecoverChampion($player, $amount=1) {
         if(PropertyContains(EffectiveCardType($obj), "CHAMPION")) {
             $actualRecovered = $obj->Damage - max(0, $obj->Damage - $amount);
             $obj->Damage = max(0, $obj->Damage - $amount);
+            if($actualRecovered > 0 && function_exists('GATelemetryBumpTurn')) {
+                GATelemetryBumpTurn(intval($player), 'healed', intval($actualRecovered));
+            }
 
             // Include the champion's stable UniqueID so the client can resolve the
             // animation on the pre-render board state even if field cleanup reindexes.

--- a/GrandArchiveSim/Custom/MaterializeLogic.php
+++ b/GrandArchiveSim/Custom/MaterializeLogic.php
@@ -882,9 +882,14 @@ $customDQHandlers["MaterializeXCost"] = function($player, $parts, $lastDecision)
 };
 
 $customDQHandlers["FINISHPAYMATERIALIZE"] = function($player, $parts, $lastDecision) {
-    $memoryCost = DecisionQueueController::GetVariable("MemoryCost");
+    $memoryCost = max(0, intval(DecisionQueueController::GetVariable("MemoryCost")));
     for($i = 0; $i < $memoryCost; ++$i) {
         MZMove($player, "myMemory-" . $i, "myBanish");//TODO: Make random
+    }
+    // This is the actual payment boundary. Record the final amount here, after reductions and
+    // alternative payments have been resolved, rather than deriving it later from card cost.
+    if($memoryCost > 0 && function_exists('GATelemetryBumpTurn')) {
+        GATelemetryBumpTurn($player, 'memorySpent', $memoryCost);
     }
     DecisionQueueController::ClearVariable("MemoryCost");
     // If the MATERIALIZE handler deferred the Materialize() call (standard cost path),
@@ -1370,6 +1375,14 @@ function DoMaterialize($player, $mzCard) {
                 }
             }
         }
+    }
+
+    // Telemetry: only reached on a successful materialize (every early return above skips it).
+    // Covers the from-material-zone / champion-lineage path; MoveEffectStackCardToField()
+    // (GameLogic.php) covers the separate from-hand-via-effect-stack path.
+    if(function_exists('GATelemetryBumpCard')) {
+        GATelemetryBumpCard($player, $sourceId, 'materialized');
+        GATelemetryBumpTurn($player, 'cardsPlayed');
     }
 }
 

--- a/GrandArchiveSim/Custom/OpportunityLogic.php
+++ b/GrandArchiveSim/Custom/OpportunityLogic.php
@@ -1261,17 +1261,20 @@ function ResolveTopOfEffectStack() {
     ReconcileEffectStackSourceZones();
     ReconcileEffectStackImbued();
     DecisionQueueController::CleanupRemovedCards();
-    $effectStack = GetLiveEffectStackEntries();
-    if(empty($effectStack)) return;
-
-    $topIndex = count($effectStack) - 1;
-    $topObj = $effectStack[$topIndex];
-    if($topObj == null) {
-        $topIndex = $topIndex - 1;
-        if($topIndex < 0) return;
-        $topObj = $effectStack[$topIndex];
-        if($topObj == null) return;
+    // Keep the physical EffectStack index. GetLiveEffectStackEntries() filters/reindexes its
+    // result, so using its count as an mzID index resolves the wrong slot whenever a removed
+    // entry leaves a hole in the underlying zone (and can strand an attack card indefinitely).
+    $effectStack = GetEffectStack();
+    $topIndex = null;
+    for($i = count($effectStack) - 1; $i >= 0; --$i) {
+        $candidate = $effectStack[$i] ?? null;
+        if($candidate !== null && empty($candidate->removed)) {
+            $topIndex = $i;
+            break;
+        }
     }
+    if($topIndex === null) return;
+    $topObj = $effectStack[$topIndex];
     $cardOwner = $topObj->Controller;
     $topMZ = "EffectStack-" . $topIndex;
     $topIsImbued = (is_array($topObj->TurnEffects ?? null) && in_array("IMBUED", $topObj->TurnEffects))

--- a/GrandArchiveSim/Formats.php
+++ b/GrandArchiveSim/Formats.php
@@ -42,6 +42,13 @@ function GAFormatDefinitions() {
             'mode'        => true,   // solo/local mode: skips structural deckbuilding rules
             'enabled'     => true,
         ],
+        'bot' => [
+            'displayName' => 'Bot Match (self-play testing)',
+            'legalSets'   => '*',
+            'banned'      => [],
+            'mode'        => true,   // solo/testing mode: skips structural deckbuilding rules
+            'enabled'     => true,
+        ],
     ];
 }
 

--- a/GrandArchiveSim/MatchHooks.php
+++ b/GrandArchiveSim/MatchHooks.php
@@ -4,6 +4,7 @@
 // old MatchFlow.php can be retired).
 require_once __DIR__ . '/../Core/Match/Hooks.php';
 require_once __DIR__ . '/Custom/DeckImport.php'; // GrandArchiveResolveDeckInput / GAValidateResolvedDeck
+require_once __DIR__ . '/StatsSubmit.php';        // GACaptureCurrentGameDetail / GASubmitMatchResults
 
 // Resolve both lobby decks into the per-seat wrapper the framework expects:
 // [seat => ['originalDeck'=>resolvedDeck, 'authKey'=>..., 'userId'=>..., 'deckLink'=>...]].
@@ -31,7 +32,9 @@ MatchRegisterHooks('GrandArchiveSim', [
     'resolveLobbyDecks' => 'GAResolveLobbyDecksForMatch',
     'validateDeck'      => 'GAValidateResolvedDeck',   // (resolvedDeck, $format)
     'setupGame'         => 'GASetupGame',
-    // optional — GA has no per-game deck stats, no login (no block), no telemetry yet.
+    // optional — GA has no per-game deck stats or login (no block) yet.
+    'captureGameDetail' => 'GACaptureCurrentGameDetail',
+    'submitResults'     => 'GASubmitMatchResults',
     'buildStatsHtml'    => (function_exists('GABuildStatsHtml') ? 'GABuildStatsHtml' : null),
     // config
     'queueTypes'        => ['bo1', 'bo3'],

--- a/GrandArchiveSim/StatsSubmit.php
+++ b/GrandArchiveSim/StatsSubmit.php
@@ -150,11 +150,25 @@ function GAPostGameResult($apiUrl, $apiKey, $payload) {
     return $last;
 }
 
+// Matches created before the preference existed keep the requested default-on behavior.
+function GAShouldShareAnonymizedGameplayData($match) {
+    return !is_array($match)
+        || !array_key_exists('shareAnonymizedGameplayData', $match)
+        || !empty($match['shareAnonymizedGameplayData']);
+}
+
 // Submit one result per decided game when the series completes. Successful games are sealed
 // individually; failed games remain retryable. The receiver deduplicates matchId:gameNumber.
 function GASubmitMatchResults($matchId) {
     $m = MatchRead('GrandArchiveSim', $matchId);
     if (!is_array($m) || ($m['state'] ?? '') !== 'complete' || !empty($m['statsSubmitted'])) return;
+    if (!GAShouldShareAnonymizedGameplayData($m)) {
+        MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) {
+            $mm['statsSubmitted'] = true;
+            $mm['statsStatus'] = 'skipped_opt_out';
+        });
+        return;
+    }
     if (count($m['players'] ?? []) > 2) {
         // GA is a 2-seat game; this guard exists only so an unexpected N-seat match can't crash here.
         MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) { $mm['statsSubmitted'] = true; $mm['statsStatus'] = 'skipped_multiplayer'; });

--- a/GrandArchiveSim/StatsSubmit.php
+++ b/GrandArchiveSim/StatsSubmit.php
@@ -1,0 +1,201 @@
+<?php
+// Assemble a full per-game telemetry payload (champion state + card stats + turn aggregates +
+// attack-by-attack combat log) from GA's Telemetry.php accumulator and POST it to an external
+// stats API, once, on final match completion. Mirrors SWUSim/StatsSubmit.php's shape/flow;
+// field names differ to reflect GA's own mechanics (Materialize/Reserve/Champion level, not
+// Play/Resource/Leader-Base) and there is no card-identifier translation step, since GA CardIDs
+// are already the stable UUID the external deckbuilders use.
+
+// Snapshot one seat's champion (cardId/element/classes/level/hp), or a zeroed shape if it
+// couldn't be resolved (e.g. an early concede before any champion materialized).
+function GASnapshotChampion($seat) {
+    $out = ['championId' => '', 'element' => '', 'classes' => [], 'level' => 0, 'hp' => 0];
+    if (!function_exists('FindChampionMZ') || !function_exists('GetZoneObject')) return $out;
+    // FindChampionMZ resolves "myField" vs "theirField" relative to the ambient $playerID global,
+    // NOT its own $player argument (GrandArchiveSim/Custom/CardDQHandlers.php) — same perspective
+    // gotcha already worked around in BotHeuristic.php's GABotOpponentChampionHP. Without pinning
+    // $playerID to this seat, whichever seat happens to equal whatever $playerID was last left at
+    // (e.g. the player who submitted the match's final action) gets its OWN champion reported
+    // correctly, while the OTHER seat silently gets the field OPPONENT's champion instead — every
+    // real match submission was at risk of one seat's championId/element/classes/level/hp being
+    // the wrong player's data.
+    global $playerID;
+    $savedPlayerID = $playerID;
+    $playerID = intval($seat);
+    // GetZoneObject() below resolves "myField"/"theirField" the same ambient-relative way, so
+    // $playerID must stay pinned through that call too, not just FindChampionMZ.
+    $mz = FindChampionMZ(intval($seat));
+    if ($mz === null) { $playerID = $savedPlayerID; return $out; }
+    $obj = GetZoneObject($mz);
+    $playerID = $savedPlayerID;
+    if ($obj === null) return $out;
+    $out['championId'] = strval($obj->CardID ?? '');
+    if (function_exists('EffectiveCardElement')) $out['element'] = strval(EffectiveCardElement($obj));
+    if (function_exists('EffectiveCardClasses')) {
+        $classes = EffectiveCardClasses($obj);
+        $out['classes'] = is_array($classes) ? array_values($classes) : (is_string($classes) ? explode(',', $classes) : []);
+    }
+    if (function_exists('ObjectCurrentLevel')) $out['level'] = intval(ObjectCurrentLevel($obj));
+    if (function_exists('ObjectCurrentHP'))    $out['hp']    = intval(ObjectCurrentHP($obj));
+    return $out;
+}
+
+// Snapshot the just-finished game's gamestate (called from the after-action hook, where the
+// gamestate is loaded and current). Returns the array stored into this game's Match.json 'detail'.
+function GACaptureCurrentGameDetail() {
+    $detail = ['firstPlayer' => 0, 'turns' => 0, 'champions' => ['1' => null, '2' => null], 'telemetry' => ['cards' => [], 'turns' => [], 'combatEvents' => []]];
+    if (function_exists('GetFirstPlayer')) { $fp = &GetFirstPlayer(); $detail['firstPlayer'] = intval($fp); }
+    if (function_exists('GetTurnNumber'))  { $tn = &GetTurnNumber();  $detail['turns'] = intval($tn); }
+    // End-game combat bypasses EndPhase(), so flush the active partial turn before copying the
+    // accumulator into Match.json. This is intentionally before the telemetry read below.
+    if (function_exists('GATelemetryFlushPendingTurns')) GATelemetryFlushPendingTurns($detail['turns']);
+    foreach ([1, 2] as $s) { $detail['champions'][strval($s)] = GASnapshotChampion($s); }
+    if (function_exists('GATelemetryGet')) {
+        $t = GATelemetryGet();
+        $detail['telemetry'] = ['cards' => $t['cards'] ?? [], 'turns' => $t['turns'] ?? [], 'combatEvents' => $t['combatEvents'] ?? []];
+    }
+    return $detail;
+}
+
+// Build the default stats-API payload for one game record (with detail attached).
+function GABuildGameResultPayload($match, $game) {
+    $d = $game['detail'] ?? [];
+    $winner = intval($game['winner'] ?? 0);
+    $tel = $d['telemetry'] ?? ['cards' => [], 'turns' => [], 'combatEvents' => []];
+    $champions = $d['champions'] ?? ['1' => null, '2' => null];
+    $buildPlayer = function($seat) use ($tel, $champions, $match) {
+        $s = strval($seat);
+        $champ = $champions[$s] ?? ['championId' => '', 'element' => '', 'classes' => [], 'level' => 0, 'hp' => 0];
+        $cardStats = [];
+        foreach (($tel['cards'][$s] ?? []) as $cid => $c) {
+            $cardStats[strval($cid)] = [
+                'drawn' => intval($c['drawn'] ?? 0), 'drawnToMemory' => intval($c['drawnToMemory'] ?? 0),
+                'materialized' => intval($c['materialized'] ?? 0), 'reserved' => intval($c['reserved'] ?? 0),
+                'discarded' => intval($c['discarded'] ?? 0), 'activated' => intval($c['activated'] ?? 0),
+            ];
+        }
+        $turnStats = [];
+        foreach (($tel['turns'] ?? []) as $tr) {
+            if (intval($tr['seat'] ?? 0) !== intval($seat)) continue;
+            $turnStats[] = [
+                'turn' => intval($tr['turn'] ?? 0), 'cardsPlayed' => intval($tr['cardsPlayed'] ?? 0),
+                'memorySpent' => intval($tr['memorySpent'] ?? 0), 'reserveSpent' => intval($tr['reserveSpent'] ?? 0),
+                'damageDealt' => intval($tr['damageDealt'] ?? 0), 'damageTaken' => intval($tr['damageTaken'] ?? 0),
+                'healed' => intval($tr['healed'] ?? 0), 'level' => intval($tr['level'] ?? 0), 'hp' => intval($tr['hp'] ?? 0),
+            ];
+        }
+        return [
+            'deckLink' => strval($match['players'][$s]['deckLink'] ?? ''),
+            'championId' => $champ['championId'], 'element' => $champ['element'], 'classes' => $champ['classes'],
+            'endLevel' => intval($champ['level']), 'endHp' => intval($champ['hp']),
+            // Cast so an empty map serializes as `{}` rather than PHP's ambiguous empty `[]`.
+            'cardStats' => (object)$cardStats, 'turnStats' => $turnStats,
+        ];
+    };
+    $matchId = strval($match['matchId'] ?? '');
+    $gameNumber = intval($game['gameNumber'] ?? 1);
+    $createdAt = intval($match['createdAt'] ?? 0);
+    return [
+        'schemaVersion' => 1,
+        'submissionId' => $matchId . ':' . $gameNumber,
+        // Match creation time is stable across retries, unlike the wall clock at delivery time.
+        'submittedAt' => gmdate('c', $createdAt > 0 ? $createdAt : 0),
+        'source' => [
+            'application' => 'TCGEngine',
+            'game' => 'GrandArchiveSim',
+            'version' => strval($GLOBALS['grandArchiveStatsSourceVersion'] ?? 'unknown'),
+        ],
+        'matchId' => $matchId, 'format' => strval($match['format'] ?? ''),
+        'bestOf' => intval($match['bestOf'] ?? 1),
+        'gameName' => strval($game['gameName'] ?? ''), 'gameNumber' => $gameNumber,
+        'winner' => $winner, 'firstPlayer' => intval($d['firstPlayer'] ?? 0), 'turns' => intval($d['turns'] ?? 0),
+        // Overall series result — known at submit time since GASubmitMatchResults only runs once
+        // the whole match is decided, so every game's payload can carry the final series outcome
+        // without the receiving API needing to correlate multiple payloads by matchId.
+        'matchWinner' => intval($match['winner'] ?? 0),
+        'matchWins' => ['1' => intval($match['wins']['1'] ?? 0), '2' => intval($match['wins']['2'] ?? 0)],
+        'players' => ['1' => $buildPlayer(1), '2' => $buildPlayer(2)],
+        'combatEvents' => $tel['combatEvents'] ?? [],
+    ];
+}
+
+function GAPostGameResult($apiUrl, $apiKey, $payload) {
+    $body = json_encode($payload);
+    if ($body === false) return ['ok' => false, 'retryable' => false, 'httpCode' => 0, 'error' => 'json_encode_failed'];
+    $last = ['ok' => false, 'retryable' => true, 'httpCode' => 0, 'error' => 'not_attempted'];
+    for ($attempt = 1; $attempt <= 3; ++$attempt) {
+        $ch = curl_init($apiUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json', 'Authorization: Bearer ' . $apiKey],
+        ]);
+        $resp = curl_exec($ch);
+        $code = intval(curl_getinfo($ch, CURLINFO_HTTP_CODE));
+        $curlErr = curl_error($ch);
+        $ok = ($resp !== false && $code >= 200 && $code < 300);
+        if ($ok) {
+            $decoded = json_decode($resp, true);
+            if (is_array($decoded) && array_key_exists('success', $decoded) && $decoded['success'] === false) $ok = false;
+        }
+        if ($ok) return ['ok' => true, 'retryable' => false, 'httpCode' => $code, 'error' => ''];
+        $retryable = ($resp === false || $code === 408 || $code === 429 || $code >= 500);
+        $last = ['ok' => false, 'retryable' => $retryable, 'httpCode' => $code,
+            'error' => $curlErr !== '' ? $curlErr : substr((string)$resp, 0, 200)];
+        if (!$retryable || $attempt === 3) break;
+        usleep($attempt * 200000);
+    }
+    return $last;
+}
+
+// Submit one result per decided game when the series completes. Successful games are sealed
+// individually; failed games remain retryable. The receiver deduplicates matchId:gameNumber.
+function GASubmitMatchResults($matchId) {
+    $m = MatchRead('GrandArchiveSim', $matchId);
+    if (!is_array($m) || ($m['state'] ?? '') !== 'complete' || !empty($m['statsSubmitted'])) return;
+    if (count($m['players'] ?? []) > 2) {
+        // GA is a 2-seat game; this guard exists only so an unexpected N-seat match can't crash here.
+        MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) { $mm['statsSubmitted'] = true; $mm['statsStatus'] = 'skipped_multiplayer'; });
+        return;
+    }
+    $apiUrl = $GLOBALS['grandArchiveStatsApiUrl'] ?? '';
+    $apiKey = $GLOBALS['grandArchiveStatsApiKey'] ?? '';
+    if ($apiUrl === '' || $apiKey === '') {
+        MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) { $mm['statsStatus'] = 'skipped_unconfigured'; });
+        return;
+    }
+    $attempted = 0; $succeeded = 0; $failed = 0;
+    foreach (($m['games'] ?? []) as $gameIndex => $g) {
+        if (($g['winner'] ?? null) === null) continue;
+        if (($g['statsDelivery']['status'] ?? '') === 'success') { $succeeded++; continue; }
+        // Don't record a game that ended before Round 2 (an early concede/abandon).
+        if (intval($g['detail']['turns'] ?? 0) < 2) continue;
+        $attempted++;
+        $result = GAPostGameResult($apiUrl, $apiKey, GABuildGameResultPayload($m, $g));
+        $deliveryStatus = !empty($result['ok']) ? 'success' : (!empty($result['retryable']) ? 'retryable_failure' : 'rejected');
+        MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) use ($gameIndex, $deliveryStatus, $result) {
+            if (!isset($mm['games'][$gameIndex])) return;
+            $previousAttempts = intval($mm['games'][$gameIndex]['statsDelivery']['attempts'] ?? 0);
+            $mm['games'][$gameIndex]['statsDelivery'] = [
+                'status' => $deliveryStatus,
+                'attempts' => $previousAttempts + 1,
+                'lastAttemptAt' => time(),
+                'httpCode' => intval($result['httpCode'] ?? 0),
+            ];
+        });
+        if (!empty($result['ok'])) {
+            $succeeded++;
+        } else {
+            $failed++;
+            error_log('GA stats submit FAILED game=' . strval($g['gameName'] ?? '?')
+                . ' http=' . intval($result['httpCode'] ?? 0) . ' error=' . strval($result['error'] ?? ''));
+        }
+    }
+    $status = ($attempted === 0 && $succeeded === 0) ? 'skipped_early' : (($failed > 0) ? 'failed' : 'success');
+    MatchWithLock('GrandArchiveSim', $matchId, function (&$mm) use ($status) {
+        $mm['statsStatus'] = $status;
+        $mm['statsSubmitted'] = ($status === 'success' || $status === 'skipped_early');
+    });
+}

--- a/GrandArchiveSim/Telemetry.php
+++ b/GrandArchiveSim/Telemetry.php
@@ -1,0 +1,103 @@
+<?php
+// Per-game telemetry accumulator. Serialized in the $gTelemetry gamestate global.
+// Shape: {cards:{seat:{cardId:{drawn,drawnToMemory,materialized,reserved,discarded,activated}}},
+//         turns:[{seat,turn,cardsPlayed,memorySpent,reserveSpent,damageDealt,damageTaken,healed,level,hp}],
+//         cur:{seat:{...running per-turn...}},
+//         combatEvents:[{type:"attack_initiated",...} | {type:"damage_resolved",...}]}
+// Mirrors SWUSim/Telemetry.php's shape/conventions; GA-specific fields (materialized/reserved
+// instead of played/resourced, drawnToMemory, level, combatEvents) reflect GA's own zones/mechanics.
+function GATelemetrySeatOk($seat) {
+    $s = intval($seat);
+    $max = function_exists('SeatCountForGame') ? SeatCountForGame() : 2;
+    return $s >= 1 && $s <= $max;
+}
+function GATelemetryGet() {
+    global $gTelemetry;
+    $d = json_decode((string)$gTelemetry, true);
+    if (!is_array($d)) $d = [];
+    $d += ['cards' => [], 'turns' => [], 'cur' => [], 'combatEvents' => []];
+    return $d;
+}
+function GATelemetrySet(array $d) {
+    global $gTelemetry;
+    $gTelemetry = json_encode($d);
+}
+function GATelemetryInit() {
+    global $gTelemetry;
+    $gTelemetry = json_encode(['cards' => [], 'turns' => [], 'cur' => [], 'combatEvents' => []]);
+}
+function GATelemetryBumpCard($seat, $cardId, $field, $n = 1) {
+    $seat = strval(intval($seat)); $cardId = strval($cardId);
+    if (!GATelemetrySeatOk($seat) || $cardId === '') return;
+    $d = GATelemetryGet();
+    $cur = $d['cards'][$seat][$cardId] ?? ['drawn'=>0,'drawnToMemory'=>0,'materialized'=>0,'reserved'=>0,'discarded'=>0,'activated'=>0];
+    if (!isset($cur[$field])) $cur[$field] = 0;
+    $cur[$field] += $n;
+    $d['cards'][$seat][$cardId] = $cur;
+    GATelemetrySet($d);
+}
+function GATelemetryBumpTurn($seat, $field, $n = 1) {
+    $seat = strval(intval($seat));
+    if (!GATelemetrySeatOk($seat)) return;
+    $d = GATelemetryGet();
+    $cur = $d['cur'][$seat] ?? [];
+    $cur[$field] = ($cur[$field] ?? 0) + $n;
+    $d['cur'][$seat] = $cur;
+    GATelemetrySet($d);
+}
+// Append one combat event (attack_initiated or damage_resolved). $event is a plain assoc array;
+// the caller is responsible for its shape (see GrandArchiveSim/StatsSubmit.php for the contract).
+function GATelemetryLogCombatEvent(array $event) {
+    $d = GATelemetryGet();
+    $d['combatEvents'][] = $event;
+    GATelemetrySet($d);
+}
+// Finalize the running per-turn counters for $seat into a turns[] record, then clear them.
+// Reads the seat's champion HP/Level at the moment of the snapshot (end of that seat's turn).
+function GATelemetrySnapshotTurn($seat, $turnNumber = null) {
+    $seat = strval(intval($seat));
+    if (!GATelemetrySeatOk($seat)) return;
+    $d = GATelemetryGet();
+    $cur = $d['cur'][$seat] ?? [];
+    $level = 0; $hp = 0;
+    if (function_exists('FindChampionMZ') && function_exists('GetZoneObject')) {
+        // Both helpers resolve my/their zone names from the ambient viewer perspective, not
+        // from FindChampionMZ's argument. Pin that perspective while reading this seat.
+        global $playerID;
+        $savedPlayerID = $playerID;
+        $playerID = intval($seat);
+        $champMZ = FindChampionMZ(intval($seat));
+        $champObj = $champMZ !== null ? GetZoneObject($champMZ) : null;
+        $playerID = $savedPlayerID;
+        if ($champObj !== null) {
+            if (function_exists('ObjectCurrentLevel')) $level = intval(ObjectCurrentLevel($champObj));
+            if (function_exists('ObjectCurrentHP'))    $hp    = intval(ObjectCurrentHP($champObj));
+        }
+    }
+    $turnNo = $turnNumber !== null ? intval($turnNumber) : (function_exists('GetTurnNumber') ? intval(GetTurnNumber()) : 0);
+    $d['turns'][] = [
+        'seat'          => intval($seat),
+        'turn'          => $turnNo,
+        'cardsPlayed'   => intval($cur['cardsPlayed'] ?? 0),
+        'memorySpent'   => intval($cur['memorySpent'] ?? 0),
+        'reserveSpent'  => intval($cur['reserveSpent'] ?? 0),
+        'damageDealt'   => intval($cur['damageDealt'] ?? 0),
+        'damageTaken'   => intval($cur['damageTaken'] ?? 0),
+        'healed'        => intval($cur['healed'] ?? 0),
+        'level'         => $level,
+        'hp'            => $hp,
+    ];
+    $d['cur'][$seat] = [];
+    GATelemetrySet($d);
+}
+
+// A game can end during its active turn (most commonly from lethal combat), before EndPhase()
+// gets a chance to snapshot it. Capture every seat with pending counters so the final payload
+// includes both the acting player's damage/cards and the defending player's damage taken.
+function GATelemetryFlushPendingTurns($turnNumber = null) {
+    $d = GATelemetryGet();
+    foreach (($d['cur'] ?? []) as $seat => $cur) {
+        if (!is_array($cur) || count($cur) === 0) continue;
+        GATelemetrySnapshotTurn(intval($seat), $turnNumber);
+    }
+}

--- a/GrandArchiveSim/Tests/BotFixtures/worlds2026_deck_a.txt
+++ b/GrandArchiveSim/Tests/BotFixtures/worlds2026_deck_a.txt
@@ -1,0 +1,33 @@
+# Worlds 2026 decklist #0 (1)
+# Material
+1 Sabrina, Spirit of Water
+1 Ciel, Loyal Valet
+1 Backup Charger
+1 Bulwark Sword
+1 Fire Resonance Bauble
+1 Manxome Armoire
+1 Nullifying Mirror
+1 The Looking Glass
+1 Wind Resonance Bauble
+1 Vaporjet Shield
+1 Inert Sword
+1 Palvor Sword
+# Main
+4 Bladed Riftseer
+2 Gildas, Chronicler of Aesa
+2 Heavy Swing
+4 Aquifer Seneschal
+4 Cerulean Decree
+4 Corhazi Trapper
+2 Extricating Touch
+4 Fracturize
+2 Freezing Hail
+2 Frostbind
+4 Frostsworn Paladin
+3 Frozen Dismissal
+4 Jueying, Shadowmare
+4 Nia, Mistveiled Scout
+4 Snow White, Weiss Queen
+4 Storm of Thorns
+3 Tweedledee, Contrarian Poet
+4 Cheshire Cat, Impish Grin

--- a/GrandArchiveSim/Tests/BotFixtures/worlds2026_deck_b.txt
+++ b/GrandArchiveSim/Tests/BotFixtures/worlds2026_deck_b.txt
@@ -1,0 +1,37 @@
+# Worlds 2026 decklist #1 (231)
+# Material
+1 Backup Charger
+1 Clarent, Reimagined
+1 Clarent, Sword of Peace
+1 Drawn Blade
+1 Lorraine, Blademaster
+1 Lorraine, Spirit Ruler
+1 Lorraine, Wandering Warrior
+1 Lost Providence
+1 Prismatic Edge
+1 Purifying Thurible
+1 Spirit of Wind
+1 Sword of Seeking
+# Main
+3 Aella, Zephyr's Hand
+3 Aesan Protector
+2 Calming Breeze
+2 Crux Sight
+3 Displace
+4 Dungeon Guide
+3 Escape the Wreckage
+4 Fairy Whispers
+4 Fluffy Shopkeep
+4 Ghosts of Pendragon
+3 Imperious Galebind
+1 Inverted Pyroslash
+1 Obsequious Blow
+4 Reclaim
+3 Scout the Land
+4 Spirit Blade: Ascension
+2 Spirit Blade: Retribution
+1 Stifling Trap
+2 Turbo Charge
+3 Veiling Breeze
+2 Verdigris Decree
+4 Windmill Engineer

--- a/GrandArchiveSim/Tests/StatsSubmitContractTest.php
+++ b/GrandArchiveSim/Tests/StatsSubmitContractTest.php
@@ -8,6 +8,16 @@ function GAStatsContractCheck($condition, $message) {
     }
 }
 
+// Minimal match-store double for exercising the delivery gate without HTTP or filesystem writes.
+$GLOBALS['gaStatsContractStoredMatch'] = null;
+function MatchRead($rootName, $matchId) {
+    return $GLOBALS['gaStatsContractStoredMatch'];
+}
+function MatchWithLock($rootName, $matchId, callable $fn) {
+    $fn($GLOBALS['gaStatsContractStoredMatch']);
+    return $GLOBALS['gaStatsContractStoredMatch'];
+}
+
 $GLOBALS['grandArchiveStatsSourceVersion'] = 'contract-test';
 $match = [
     'matchId' => 'contract-match', 'format' => 'premier', 'bestOf' => 1,
@@ -37,5 +47,19 @@ GAStatsContractCheck(!array_key_exists('apiKey', $payload), 'credential is not i
 GAStatsContractCheck(str_starts_with($payload['submittedAt'], '2024-08-24T16:00:00'), 'submission timestamp is stable');
 GAStatsContractCheck(str_contains($encoded, '"cardStats":{}'), 'empty cardStats serializes as an object');
 GAStatsContractCheck($decoded['players']['1']['championId'] === 'champion-one', 'player champion is retained');
+GAStatsContractCheck(GAShouldShareAnonymizedGameplayData([]), 'legacy matches default to sharing');
+GAStatsContractCheck(GAShouldShareAnonymizedGameplayData(['shareAnonymizedGameplayData' => true]), 'enabled matches share');
+GAStatsContractCheck(!GAShouldShareAnonymizedGameplayData(['shareAnonymizedGameplayData' => false]), 'opted-out matches do not share');
+
+$GLOBALS['gaStatsContractStoredMatch'] = [
+    'matchId' => 'opted-out-match',
+    'state' => 'complete',
+    'shareAnonymizedGameplayData' => false,
+    'players' => ['1' => [], '2' => []],
+    'games' => [],
+];
+GASubmitMatchResults('opted-out-match');
+GAStatsContractCheck($GLOBALS['gaStatsContractStoredMatch']['statsSubmitted'] === true, 'opt-out is sealed without retrying');
+GAStatsContractCheck($GLOBALS['gaStatsContractStoredMatch']['statsStatus'] === 'skipped_opt_out', 'opt-out records an explicit status');
 
 echo "Grand Archive stats payload contract: PASS" . PHP_EOL;

--- a/GrandArchiveSim/Tests/StatsSubmitContractTest.php
+++ b/GrandArchiveSim/Tests/StatsSubmitContractTest.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../StatsSubmit.php';
+
+function GAStatsContractCheck($condition, $message) {
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: " . $message . PHP_EOL);
+        exit(1);
+    }
+}
+
+$GLOBALS['grandArchiveStatsSourceVersion'] = 'contract-test';
+$match = [
+    'matchId' => 'contract-match', 'format' => 'premier', 'bestOf' => 1,
+    'winner' => 1, 'wins' => ['1' => 1, '2' => 0], 'createdAt' => 1724515200,
+    'players' => ['1' => ['deckLink' => ''], '2' => ['deckLink' => '']],
+];
+$game = [
+    'gameName' => 'contract-game', 'gameNumber' => 1, 'winner' => 1,
+    'detail' => [
+        'firstPlayer' => 2, 'turns' => 4,
+        'champions' => [
+            '1' => ['championId' => 'champion-one', 'element' => 'FIRE', 'classes' => ['WARRIOR'], 'level' => 2, 'hp' => 10],
+            '2' => ['championId' => 'champion-two', 'element' => 'WIND', 'classes' => ['RANGER'], 'level' => 2, 'hp' => 0],
+        ],
+        'telemetry' => ['cards' => [], 'turns' => [], 'combatEvents' => []],
+    ],
+];
+
+$payload = GABuildGameResultPayload($match, $game);
+$encoded = json_encode($payload);
+$decoded = json_decode($encoded, true);
+
+GAStatsContractCheck($payload['schemaVersion'] === 1, 'schemaVersion is 1');
+GAStatsContractCheck($payload['submissionId'] === 'contract-match:1', 'submission identity is stable');
+GAStatsContractCheck($payload['source']['version'] === 'contract-test', 'source version is emitted');
+GAStatsContractCheck(!array_key_exists('apiKey', $payload), 'credential is not in the payload');
+GAStatsContractCheck(str_starts_with($payload['submittedAt'], '2024-08-24T16:00:00'), 'submission timestamp is stable');
+GAStatsContractCheck(str_contains($encoded, '"cardStats":{}'), 'empty cardStats serializes as an object');
+GAStatsContractCheck($decoded['players']['1']['championId'] === 'champion-one', 'player champion is retained');
+
+echo "Grand Archive stats payload contract: PASS" . PHP_EOL;

--- a/ProcessInput.php
+++ b/ProcessInput.php
@@ -15,6 +15,12 @@ include_once "./Core/ViewerIdentity.php";
 include_once "./AccountFiles/AccountSessionAPI.php";
 include_once "./AccountFiles/AccountDatabaseAPI.php";
 include_once "./Database/ConnectionManager.php";
+// Match completion (via EngineActionRunner -> MatchAfterActionHook -> the submitResults hook) can
+// happen on any action request, and stats submission (SWU's SubmitMatchResults, GA's
+// GASubmitMatchResults) reads its API key from these globals. Without this include here — the only
+// place MatchAfterActionHook is actually invoked from in a live game — every real submission runs
+// with an unset key and gets rejected/silently skipped.
+include_once "./APIKeys/APIKeys.php";
 
 $processInputResponseFormat = strtolower(strval($_GET["responseFormat"] ?? ""));
 

--- a/Schemas/GrandArchiveSim/GameSchema.txt
+++ b/Schemas/GrandArchiveSim/GameSchema.txt
@@ -10,7 +10,7 @@ ServerInclude: /TurnController.php
 ServerInclude: /GeneratedCode/GeneratedMacroCode.php
 ServerInclude: /GeneratedCode/GeneratedKeywordCode.php
 AssetReflection: GrandArchiveSim
-Module: Versions=TurnPlayer,CurrentPhase,TurnNumber,PhaseParameters,myHand,myTempZone,myGraveyard,myDeck,myDecisionQueue,myHealth,myMastery,myGlobalEffects,myMaterial,myField,myIntent,myMemory,myBanish,theirHand,theirTempZone,theirGraveyard,theirDeck,theirDecisionQueue,theirHealth,theirMastery,theirGlobalEffects,theirMaterial,theirField,theirIntent,theirMemory,theirBanish,DecisionQueueVariables,EffectStack,MacroTurnIndex,UniqueIDCounter,MacroGameIndex,RandomCounter
+Module: Versions=TurnPlayer,CurrentPhase,TurnNumber,PhaseParameters,myHand,myTempZone,myGraveyard,myDeck,myDecisionQueue,myHealth,myMastery,myGlobalEffects,myMaterial,myField,myIntent,myMemory,myBanish,theirHand,theirTempZone,theirGraveyard,theirDeck,theirDecisionQueue,theirHealth,theirMastery,theirGlobalEffects,theirMaterial,theirField,theirIntent,theirMemory,theirBanish,DecisionQueueVariables,EffectStack,MacroTurnIndex,UniqueIDCounter,MacroGameIndex,RandomCounter,Telemetry
 Module: UniqueID=Field,UniqueID,UniqueIDCounter
 Module: ShortcutWindows={"REC_START":{"label":"Recollection Start","default":false,"group":"Phase","order":10},"END_START":{"label":"End Phase Start","default":false,"group":"Phase","order":20},"STACK_RESPONSE":{"label":"Effect Stack Response","default":false,"group":"Priority","order":30},"ENTER_RESPONSE":{"label":"On Enter Response","default":true,"group":"Priority","order":35},"TRIGGER_RESPONSE":{"label":"Triggered Abilities","default":true,"group":"Priority","order":37},"ABILITY_RESPONSE":{"label":"Ability Response","default":false,"group":"Priority","order":40},"COMBAT_DAMAGE":{"label":"Combat Damage Window","default":false,"group":"Combat","order":50},"COMBAT_RETALIATION":{"label":"Combat Retaliation","default":false,"group":"Combat","order":60}}
 Module: MatchReplay=MatchReplayInitialState,MatchReplayCommands
@@ -231,4 +231,6 @@ Display: Visibility=None, Mode=Value, Scope=Global, Display=None
 MatchReplayInitialState - Value:string=-
 Display: Visibility=None, Mode=Value, Scope=Global, Display=None
 MatchReplayCommands - Value:string=-
+Display: Visibility=None, Mode=Value, Scope=Global, Display=None
+Telemetry - Value:string=-
 Display: Visibility=None, Mode=Value, Scope=Global, Display=None

--- a/SharedUI/Sites/GrandArchiveSim/MainMenu.php
+++ b/SharedUI/Sites/GrandArchiveSim/MainMenu.php
@@ -789,8 +789,22 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
           var params = new URLSearchParams(window.location.search || '');
           var deckLinkParam = (params.get('deckLink') || params.get('deck') || '').trim();
           var deckTextParam = (params.get('deckText') || params.get('list') || '').trim();
+          var deck2Param = (params.get('deckLink2') || params.get('deck2') || params.get('deckText2') || '').trim();
+          var formatParam = (params.get('format') || '').trim().toLowerCase();
+          var queueTypeParam = (params.get('queueType') || '').trim().toLowerCase();
           var goldfishParam = (params.get('goldfish') || '').trim().toLowerCase();
           var shouldAutostart = goldfishParam === '1' || goldfishParam === 'true' || goldfishParam === 'yes';
+
+          var formatEl = document.getElementById('ga-format-select');
+          if (formatEl && formatParam && Array.prototype.some.call(formatEl.options, function(option) { return option.value === formatParam; })) {
+            formatEl.value = formatParam;
+            formatEl.dispatchEvent(new Event('change'));
+          }
+
+          var queueTypeEl = document.getElementById('ga-queuetype-select');
+          if (queueTypeEl && queueTypeParam && Array.prototype.some.call(queueTypeEl.options, function(option) { return option.value === queueTypeParam; })) {
+            queueTypeEl.value = queueTypeParam;
+          }
 
           if (deckLinkParam) {
             var deckLinkEl = document.getElementById('deck-link');
@@ -804,6 +818,13 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
               deckTextEl.value = deckTextParam;
             }
             switchDeckTab('text');
+          }
+
+          if (deck2Param) {
+            var deck2El = document.getElementById('ga-deck2-input');
+            if (deck2El && !deck2El.value.trim()) {
+              deck2El.value = deck2Param;
+            }
           }
 
           if (shouldAutostart && (deckLinkParam || deckTextParam)) {

--- a/SharedUI/Sites/GrandArchiveSim/MainMenu.php
+++ b/SharedUI/Sites/GrandArchiveSim/MainMenu.php
@@ -106,6 +106,13 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
           <?php endforeach; ?>
         </select>
       </div>
+      <label for="ga-share-anonymized-gameplay" style="display:flex; align-items:flex-start; gap:8px; margin:0 0 12px; color:#ddd; font-size:13px; line-height:1.35; cursor:pointer;">
+        <input type="checkbox" id="ga-share-anonymized-gameplay" checked style="margin-top:2px;">
+        <span>
+          Share anonymized gameplay data
+          <span style="display:block; color:#999; font-size:12px;">Helps improve aggregate simulator statistics. Deck, card, turn, combat, and match data may be shared; account and contact details are not included.</span>
+        </span>
+      </label>
       <div style="display: flex; gap: 10px; flex-wrap: wrap;">
         <button onclick="joinQueue()">Join Queue</button>
         <button onclick="createPrivateGame()" style="background-color: #2f6f9f;">Create Private Game</button>
@@ -860,6 +867,8 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
 
         var qtEl = document.getElementById('ga-queuetype-select');
         var queueType = qtEl ? qtEl.value : 'bo1';
+        var analyticsEl = document.getElementById('ga-share-anonymized-gameplay');
+        var shareAnonymizedGameplayData = analyticsEl ? analyticsEl.checked : true;
 
         return {
           preconstructedDeck: preconstructedDeck,
@@ -867,9 +876,24 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
           deckLink2: deckLink2,
           gameType: gameType,
           format: format,
-          queueType: queueType
+          queueType: queueType,
+          shareAnonymizedGameplayData: shareAnonymizedGameplayData
         };
       }
+
+      (function restoreAnalyticsSharingPreference(){
+        var analyticsEl = document.getElementById('ga-share-anonymized-gameplay');
+        if (!analyticsEl) return;
+        try {
+          var saved = window.localStorage.getItem('tcgengine:GrandArchiveSim:shareAnonymizedGameplayData');
+          if (saved !== null) analyticsEl.checked = saved !== 'false';
+          analyticsEl.addEventListener('change', function(){
+            window.localStorage.setItem('tcgengine:GrandArchiveSim:shareAnonymizedGameplayData', analyticsEl.checked ? 'true' : 'false');
+          });
+        } catch (e) {
+          // Storage can be unavailable in strict privacy modes; the checked default still applies.
+        }
+      })();
 
       // Hotseat needs a second deck (reveal the P2 input); mode formats (goldfish/hotseat) are Bo1-only.
       (function(){
@@ -1016,6 +1040,7 @@ $gaDeckLibraryConfig = DeckLibraryConfigFromSiteDef($gaSiteDef, ['actionButtons'
         params += "&rootName=" + encodeURIComponent(rootName);
         params += '&format=' + encodeURIComponent(submission.format || 'standard');
         params += '&queueType=' + encodeURIComponent(submission.queueType || 'bo1');
+        params += '&shareAnonymizedGameplayData=' + (submission.shareAnonymizedGameplayData ? '1' : '0');
         if (submission.deckLink2) params += '&deckLink2=' + encodeURIComponent(submission.deckLink2);
         if (options.createPrivate) {
           params += '&createPrivate=1';


### PR DESCRIPTION
## Summary

Adds Grand Archive match telemetry, reliable external stats submission, bot self-play support, and Clarent playtest URL prefilling.

### Changes

- Captures per-game Grand Archive telemetry:
  - Champion identity, element, class, level, and ending HP
  - Card draw, memory, materialization, reserve, discard, and activation counts
  - Per-turn resource, damage, healing, level, and HP statistics
  - Combat initiation and resolved-damage events
- Submits a versioned payload after a completed BO1 or BO3 match.
- Uses bearer-token authentication rather than placing credentials in payloads.
- Adds stable submission IDs for receiver-side idempotency.
- Retries transient failures and records delivery state per game.
- Leaves failed submissions retryable instead of prematurely sealing them.
- Adds configurable API URL, secret, and source-version placeholders to the ignored API-key configuration.
- Adds Grand Archive bot-match format and deterministic bot action support.
- Adds a portable browserless bot-vs-bot test harness using real tournament deck fixtures.
- Supports exporting completed headless-game telemetry for local analytics testing.
- Adds Clarent query-parameter prefilling for:
  - Player 1 deck link or deck text
  - Player 2 deck link or deck text
  - Goldfish and Hotseat formats
  - BO1/BO3 queue type
- Improves related game setup, materialization, opportunity, combat, and decision handling uncovered by self-play testing.

## Validation

- PHP syntax checks passed for all changed PHP files.
- Grand Archive stats payload contract test passed.
- Grand Archive match-hook regression test passed.
- Deterministic headless self-play:
  - Completed in 131 bot steps
  - 10/10 telemetry assertions passed
  - 12 turn snapshots captured
  - 18 combat events captured
- Local end-to-end analytics test:
  - Headless payload accepted by the local ingestion Worker
  - One game and two player rows stored in D1
  - Duplicate retry correctly returned `duplicate`
  - Analytics correctly reported the champion matchup and winner

## Configuration

Production requires the following server-only values in the ignored `APIKeys/APIKeys.php` file:

```php
$grandArchiveStatsApiUrl = "...";
$grandArchiveStatsApiKey = "...";
$grandArchiveStatsSourceVersion = "...";
```

No credentials are included in this merge request.